### PR TITLE
(g|s)etfenv fixes

### DIFF
--- a/lua/pl/utils.lua
+++ b/lua/pl/utils.lua
@@ -234,6 +234,7 @@ else
     end
 
     function getfenv(f)
+        local f = f or 0
         f = (type(f) == 'function' and f or debug.getinfo(f + 1, 'f').func)
         local name, val
         local up = 0


### PR DESCRIPTION
Hi Steve, I added some small changes to get/setfenv to make them more closely some edge-casey behavior in 5.1 that Telescope depends on.

I actually intend to change Telescope to make it work without this patch applied, but I thought it would still be good to send these changes over since it makes Penlight's behavior closer to that documented for 5.1.
