### PR TITLE
Slight improvement to tablex.merge

### DIFF
--- a/lua/pl/tablex.lua
+++ b/lua/pl/tablex.lua
@@ -515,8 +515,10 @@ function tablex.merge (t1,t2,dup)
     for k,v in pairs(t1) do
         if dup or t2[k] then res[k] = v end
     end
-    for k,v in pairs(t2) do
-        if dup or t1[k] then res[k] = v end
+    if dup then
+      for k,v in pairs(t2) do
+        res[k] = v
+      end
     end
     return setmeta(res,t1,Map)
 end

--- a/tests/test-tablex.lua
+++ b/tests/test-tablex.lua
@@ -127,4 +127,5 @@ asserteq(t,{1,0,0,4,5,6})
 insertvalues(t,1,{10,20})
 asserteq(t,{10,20,1,0,0,4,5,6})
 
-
+asserteq(merge({10,20,30},{nil, nil, 30, 40}), {[3]=30})
+asserteq(merge({10,20,30},{nil, nil, 30, 40}, true), {10,20,30,40})


### PR DESCRIPTION
I think you can hoist "dup" out of tablex.merge's second loop.  I added a test for the same.
