### PR TITLE
Optional arguments

### DIFF
--- a/lua/pl/lapp.lua
+++ b/lua/pl/lapp.lua
@@ -224,11 +224,17 @@ function lapp.process_options_string(str,args)
         if res.rest then
             line = res.rest
             res = {}
-            -- do we have ([<type>] [default <val>])?
+            local optional
+            -- do we have ([optional] [<type>] [default <val>])?
             if match('$({def} $',line,res) or match('$({def}',line,res) then
                 local typespec = strip(res.def)
                 local ftype, rest = typespec:match('^(%S+)(.*)$')
                 rest = strip(rest)
+                if ftype == 'optional' then
+                    ftype, rest = rest:match('^(%S+)(.*)$')
+                    rest = strip(rest)
+                    optional = true
+                end
                 local default
                 if ftype == 'default' then
                     default = true
@@ -271,7 +277,7 @@ function lapp.process_options_string(str,args)
             local ps = {
                 type = vtype,
                 defval = defval,
-                required = defval == nil,
+                required = defval == nil and not optional,
                 comment = res.rest or optparm,
                 constraint = constraint,
                 varargs = varargs

--- a/tests/test-lapp.lua
+++ b/tests/test-lapp.lua
@@ -96,3 +96,11 @@ local with_dashes = [[
 
 check(with_dashes,{'--first-dash'},{first_dash=true,second_dash=false})
 
+local optional = [[
+  -p (optional string)
+]]
+
+check(optional,{'-p', 'test'},{p='test'})
+check(optional,{},{})
+
+


### PR DESCRIPTION
With this you can go

```
-o,--optional-arg (optional string) You don't neet to use this arg
```

I don't know that it's the best syntax, any better ideas?
