### PR TITLE
Corrected typo introduced by commit 0b5b454.

### DIFF
--- a/lua/pl/Set.lua
+++ b/lua/pl/Set.lua
@@ -52,7 +52,7 @@ function Set:_init (t)
 end
 
 function Set:__tostring ()
-    return '['..concat(array_tostring(Set.values(self),','))..']'
+    return '['..concat(array_tostring(Set.values(self)),',')..']'
 end
 
 --- get a list of the values in a set.


### PR DESCRIPTION
Assertions on Set.__tostring() are explicitely disabled in test-set.lua because of ordering issues, so this typo escaped the checks.
