### PR TITLE
Add support for read only tables

### DIFF
--- a/lua/pl/tablex.lua
+++ b/lua/pl/tablex.lua
@@ -825,9 +825,10 @@ end
 function tablex.readonly(t)
 	local mt = {
 		__index=t,
-		__newindex=function(t, k, v)
-			error("Attempt to modify read-only table", 2)
-		end,
+		__newindex=function(t, k, v) error("Attempt to modify read-only table", 2) end,
+		__pairs=function() return pairs(t) end,
+		__ipairs=function() return ipairs(t) end,
+		__len=function() return #t end,
 		__metatable=false
 	}
 	return setmetatable({}, mt)


### PR DESCRIPTION
Add support for making a table read only. I find this helpful when used in conjunction with pl.config. After reading the config into a table then adding any default values I make the table read only to prevent accidental modification. In my use I have some config values that shouldn't change (db salt) and I'd rather have modification of that value produce an error instead of having unintended and unforeseen consequences.

Uses the methods described at:
http://lua-users.org/wiki/ReadOnlyTables
http://www.lua.org/pil/13.4.5.html
