### PR TITLE
Fixed lapp.add_type which was broken due to uninitialized table variable

### DIFF
--- a/lua/pl/lapp.lua
+++ b/lua/pl/lapp.lua
@@ -108,7 +108,7 @@ local function xtonumber(s)
     return val
 end
 
-local types
+local types = {}
 
 local builtin_types = {string=true,number=true,['file-in']='file',['file-out']='file',boolean=true}
 
@@ -173,7 +173,6 @@ function lapp.process_options_string(str,args)
     parms = {}
     aliases = {}
     parmlist = {}
-    types = {}
 
     local function check_varargs(s)
         local res,cnt = s:gsub('^%.%.%.%s*','')

--- a/tests/test-lapp.lua
+++ b/tests/test-lapp.lua
@@ -1,6 +1,8 @@
 
 local test = require 'pl.test'
 local lapp = require 'pl.lapp'
+local utils = require 'pl.utils'
+local tablex = require 'pl.tablex'
 
 local k = 1
 function check (spec,args,match)
@@ -103,4 +105,20 @@ local optional = [[
 check(optional,{'-p', 'test'},{p='test'})
 check(optional,{},{})
 
+local addtype = [[
+  -l (intlist) List of items
+]]
 
+lapp.add_type('intlist',
+              function(x)
+                 return tablex.imap(tonumber, utils.split(x, '%s*,%s*'))
+              end,
+              function(x)
+                 for _,v in ipairs(x) do
+                    lapp.assert(math.ceil(v) == v,'not an integer!')
+                 end
+              end)
+
+check(addtype,{'-l', '1,2,3'},{l={1,2,3}})
+
+check_error(addtype,{'-l', '1.5,2,3'},"not an integer!")


### PR DESCRIPTION
The variable `types` was not initialized preventing `add_type` from
appending custom types to the variable. I also added a new test to
cover this test case in the future.
