### PR TITLE
Added iterators to allow traversing tables in a sorted manner

### DIFF
--- a/docs/manual/02-arrays.md
+++ b/docs/manual/02-arrays.md
@@ -402,6 +402,21 @@ compare the two sets, as above:
 (Note the special string '==' above; instead of saying `ops.gt` or `ops.eq` we
 can use the strings '>' or '==' respectively.)
 
+`sort` and `sortv` return iterators that will iterate through the
+sorted elements of a table. `sort` iterates by sorted key order, and
+`sortv` iterates by sorted value order. For example, given a table
+with names and ages, it is trivial to iterate over the elements:
+
+    > t = {john=27,jane=31,mary=24}
+    > for name,age in tablex.sort(t) do print(name,age) end
+    jane    31
+    john    27
+    mary    24
+    > for name,age in tablex.sortv(t) do print(name,age) end
+    mary    24
+    john    27
+    jane    31
+
 There are several ways to merge tables in PL. If they are list-like, then see the
 operations defined by `pl.List`, like concatenation. If they are map-like, then
 `merge` provides two basic operations. If the third arg is false, then the result

--- a/lua/pl/tablex.lua
+++ b/lua/pl/tablex.lua
@@ -6,7 +6,7 @@
 -- @module pl.tablex
 local utils = require ('pl.utils')
 local getmetatable,setmetatable,require = getmetatable,setmetatable,require
-local append,remove = table.insert,table.remove
+local tsort,append,remove = table.sort,table.insert,table.remove
 local min,max = math.min,math.max
 local pairs,type,unpack,next,select,tostring = pairs,type,unpack,next,select,tostring
 local function_arg = utils.function_arg
@@ -816,5 +816,38 @@ function tablex.search (t,value,exclude)
     end
     return _find(t,value,tables)
 end
+
+--- return an iterator to a table sorted by its keys
+-- @param t the table
+-- @param comp an optional comparison function (comp(x,y) is true if x < y)
+-- @usage for k,v in tablex.sort(t) do print(k,v) end
+-- @return an iterator to traverse elements sorted by the keys
+function tablex.sort(t,f)
+   local keys = {}
+   for k in pairs(t) do keys[#keys + 1] = k end
+   tsort(keys,f)
+   local i = 0
+   return function()
+      i = i + 1
+      return keys[i], t[keys[i]]
+   end
+end
+
+--- return an iterator to a table sorted by its values
+-- @param t the table
+-- @param comp an optional comparison function (comp(x,y) is true if x < y)
+-- @usage for k,v in tablex.sortv(t) do print(k,v) end
+-- @return an iterator to traverse elements sorted by the values
+function tablex.sortv(t,f)
+   local rev = {}
+   for k,v in pairs(t) do rev[v] = k end
+   local next = tablex.sort(rev,f)
+   return function()
+      local value,key = next()
+      return key,value
+   end
+end
+
+
 
 return tablex

--- a/tests/test-tablex.lua
+++ b/tests/test-tablex.lua
@@ -137,3 +137,26 @@ asserteq(t,{10,20,1,0,0,4,5,6})
 
 asserteq(merge({10,20,30},{nil, nil, 30, 40}), {[3]=30})
 asserteq(merge({10,20,30},{nil, nil, 30, 40}, true), {10,20,30,40})
+
+
+-- Function to check that the order of elements returned by the iterator
+-- match the order of the elements in the list.
+function assert_iter_order(iter,l)
+   local i = 0
+   for k,v in iter do
+      i = i + 1
+      asserteq(k,l[i][1])
+      asserteq(v,l[i][2])
+   end
+end   
+
+local t = {a=10,b=9,c=8,d=7,e=6,f=5,g=4,h=3,i=2,j=1}
+
+assert_iter_order(
+   sort(t), 
+   {{'a',10},{'b',9},{'c',8},{'d',7},{'e',6},{'f',5},{'g',4},{'h',3},{'i',2},{'j',1}})
+                    
+assert_iter_order(
+   sortv(t), 
+   {{'j',1},{'i',2},{'h',3},{'g',4},{'f',5},{'e',6},{'d',7},{'c',8},{'b',9},{'a',10}})
+


### PR DESCRIPTION
Here is my first pass at the two functions. I'm a complete newbie so please review closely.

I struggled with the names of the two functions, but finally settled on `sort` (returns iterator that traverses by sorted key order - the most common use case) and `sortv` (for traversing by sorted value order - less common). I added them to `tablex` because I wouldn't know where to begin with finding a right home for them per your comment about `tablex` getting too large (baby steps).

I added two test cases to validate the functions work. I had to think about how best to do that as I had to compare elements from the iterator to make sure they were in the right order, so I wrote a helper function to do so.

Finally, I updated the PL manual with a new paragraph in the array section of the document. 

This would close issue #52. 
