### PR TITLE
Add function to create a table with case insentive key lookup.

### DIFF
--- a/lua/pl/tablex.lua
+++ b/lua/pl/tablex.lua
@@ -886,10 +886,10 @@ function tablex.create_case_insensitive()
             local v = nil
             if type(k) == "string" then
                 -- Try to get the value for the key normalized.
-                v = rawget(values, k:lower())
+                v = values[k:lower()]
             end
             if v == nil then
-                v = rawget(values, k)
+                v = values[k]
             end
             return v
         end,
@@ -899,7 +899,7 @@ function tablex.create_case_insensitive()
                 lookup[k:lower()] = v ~= nil and k or nil -- Clear the lookup value if we're setting to nil.
                 k = k:lower()
             end
-            rawset(values, k, v)
+            values[k] = v
         end,
         __pairs=function(t)
             local function n(t, i)

--- a/lua/pl/tablex.lua
+++ b/lua/pl/tablex.lua
@@ -877,16 +877,12 @@ function tablex.create_case_insensitive()
 	local lookup = {} -- For case preservation.
 	local mt = {
 		__index=function(t, k)
-			local v
+			local v = nil
 			if type(k) == "string" then
 				-- Try to get the value for the key normalized.
 				v = rawget(t, k:lower())
-				-- If we don't have a normalized key we might be dealing with a rawset
-				-- so try to get it non-normalized.
-				if v == nil then
-					v = rawget(t, k)
-				end
-			else
+			end
+			if v == nil then
 				v = rawget(t, k)
 			end
 			return v

--- a/lua/pl/tablex.lua
+++ b/lua/pl/tablex.lua
@@ -904,13 +904,11 @@ function tablex.create_case_insensitive()
         __pairs=function(t)
             local function n(t, i)
                 if i ~= nil then
-                    -- Check that strings that have been normalized exist in the table. If they don't
-                    -- the value could have been set exactly using rawset.
+                    -- Check that strings that have been normalized exist in the table.
                     if type(i) == "string" and values[i:lower()] ~= nil then
                         i = i:lower()
                     end
-                    -- Ensure the value exists in the table. Either due to a rawset or it's not a string
-                    -- and we still need to check it exists.
+                    -- Ensure the value exists in the table.
                     if values[i] == nil then
                         return nil
                     end

--- a/lua/pl/tablex.lua
+++ b/lua/pl/tablex.lua
@@ -890,7 +890,7 @@ function tablex.create_case_insensitive()
 		__newindex=function(t, k, v)
 			-- Store all strings normalized as lowercase.
 			if type(k) == "string" then
-				lookup[k:lower()] = k
+				lookup[k:lower()] = v ~= nil and k or nil
 				k = k:lower()
 			end
 			rawset(t, k, v)


### PR DESCRIPTION
Added a create_case_insensitive function. It creates a table where string based keys are compared in a case insensitive manner. Keys are case preserved (useful with pairs).
