### PR TITLE
Don't assume dst offset is 1 hour from std

### DIFF
--- a/lua/pl/Date.lua
+++ b/lua/pl/Date.lua
@@ -70,29 +70,32 @@ function Date:_init(t,...)
     self:set(time)
 end
 
-local tzone_
-
 --- get the time zone offset from UTC.
 -- @return seconds ahead of UTC
-function Date.tzone ()
-    if not tzone_ then
-        local now = os.time()
-        local utc = os.date('!*t',now)
-        local lcl = os.date('*t',now)
-        lcl.isdst = false
-        tzone_ = os.difftime(os.time(lcl), os.time(utc))
+function Date.tzone (ts)
+    if ts == nil then
+        ts = os.time()
+    elseif type(ts) == "table" then
+        if getmetatable(ts) == Date then
+        	ts = ts.time
+        else
+        	ts = Date(ts).time
+        end
     end
-    return tzone_
+    local utc = os.date('!*t',ts)
+    local lcl = os.date('*t',ts)
+    lcl.isdst = false
+    return os.difftime(os.time(lcl), os.time(utc))
 end
 
 --- convert this date to UTC.
 function Date:toUTC ()
-    self:add { sec = -Date.tzone() }
+    self:add { sec = -Date.tzone(self) }
 end
 
 --- convert this UTC date to local.
 function Date:toLocal ()
-    self:add { sec = Date.tzone() }
+    self:add { sec = Date.tzone(self) }
 end
 
 --- set the current time of this Date object.


### PR DESCRIPTION
Don't assume dst offset is 1 hour from standard time zone offset. Calculate the dst difference instead because it's possible dst may not be 1 hour from std.

Uses the technique by Eric Feliksik from http://lua-users.org/wiki/TimeZone .
