### PR TITLE
Updated pl.dir.file_op to return true on success and false on failure...

### DIFF
--- a/lua/pl/dir.lua
+++ b/lua/pl/dir.lua
@@ -208,10 +208,11 @@ local function file_op (is_copy,src,dest,flag)
             dest = path.normcase(dest)
             local cmd = is_copy and 'copy' or 'rename'
             local res, err = execute_command('copy',two_arguments(src,dest))
-            if not res then return nil,err end
+            if not res then return false,err end
             if not is_copy then
                 return execute_command('del',quote_argument(src))
             end
+            return true
         else
             if path.isdir(dest) then
                 dest = path.join(dest,path.basename(src))

--- a/tests/test-dir.lua
+++ b/tests/test-dir.lua
@@ -27,14 +27,45 @@ local err, msg = dir.movefile( fileName, newFileName )
 assert( err, msg )
 
 -- Check to make sure the original file is gone
-
 asserteq( path.exists( fileName ), false )
 
 -- Check to make sure the new file is there
-asserteq (path.exists( newFileName ) , newFileName)
+asserteq( path.exists( newFileName ) , newFileName )
+
+-- Try to move the original file again (which should fail)
+local newFileName2 = path.tmpname()
+local err, msg = dir.movefile( fileName, newFileName2 )
+asserteq( err, false )
 
 -- Clean up
 file.delete( newFileName )
+
+
+-- Test copy files -----------------------------------------
+
+-- Create a dummy file
+local fileName = path.tmpname()
+file.write( fileName, string.rep( "poot ", 1000 ) )
+
+local newFileName = path.tmpname()
+local err, msg = dir.copyfile( fileName, newFileName )
+
+-- Make sure the move is successful
+assert( err, msg )
+
+-- Check to make sure the new file is there
+asserteq( path.exists( newFileName ) , newFileName )
+
+-- Try to move a non-existant file (which should fail)
+local fileName2 = path.tmpname()
+local newFileName2 = path.tmpname()
+local err, msg = dir.copyfile( fileName2, newFileName2 )
+asserteq( err, false )
+
+-- Clean up the files
+file.delete( fileName )
+file.delete( newFileName )
+
 
 -- have NO idea why forcing the return code is necessary here (Windows 7 64-bit)
 os.exit(0)


### PR DESCRIPTION
...when falling back to DOS commands.

The fallback to DOS commands (when alien is not available) now returns false,err on failure and true on success as stated in the documentation.
Tests for copying have been added and those for move have been updated.
