### PR TITLE
More Robust Quoted Strings

### DIFF
--- a/tests/test-pretty.lua
+++ b/tests/test-pretty.lua
@@ -47,9 +47,12 @@ asserteq(res,{a=2,bonzo='dog',t={1,2,3}})
 res,err = pretty.read [[
 {s = ('woo'):gsub('w','wwwwww'):gsub('w','wwwwww')}
 ]]
-
-assertmatch(err,utils.lua51 and 'attempt to index a string value' or "attempt to index constant 'woo'")
-
+--AAS
+if _VERSION == "Lua 5.3" then
+  assertmatch(err, [=[attempt to index a string value]=])
+else
+  assertmatch(err,utils.lua51 and 'attempt to index a string value'  or "attempt to index constant 'woo'")
+end
 ---- pretty.load has a _paranoid_ option
 res,err = pretty.load([[
 k = 0

--- a/tests/test-stringx.lua
+++ b/tests/test-stringx.lua
@@ -270,3 +270,63 @@ asserteq(stringx.strip('    hello         '),'hello')
 asserteq(stringx.strip('--[hello] -- - ','-[] '),'hello')
 asserteq(stringx.rstrip('--[hello] -- - ','-[] '),'--[hello')
 
+-- 
+
+
+local assert_str_round_trip = function(s)
+	
+	local qs = stringx.quote_string(s)
+	local compiled, err = load("return "..qs)
+
+	if not compiled then
+		print(
+			("stringx.quote_string assert failed: invalid string created: Received:\n%s\n\nCompiled to\n%s\n\nError:\t%s\n"):
+			format(s, qs, err)
+		)
+		error()
+	else
+		compiled = compiled()
+	end
+
+	if compiled ~= s then
+		print("strinx.quote_string assert Failed: String compiled but did not round trip.")
+		print("input string:\t\t",s, #s)
+		print("compiled string:\t", compiled, #compiled)
+		print("output string:\t\t",qs, #qs)
+		error()
+	else
+		-- print("input string:\t\t",s)
+		-- print("compiled string:\t", compiled)
+		-- print("output string:\t\t",qs)
+	end
+end
+
+assert_str_round_trip( "normal string with nothing weird.")
+assert_str_round_trip( "Long string quoted with escaped quote \\\" and a long string pattern match [==[ found near the end.")
+
+assert_str_round_trip( "Unescapped quote \" in the middle")
+assert_str_round_trip( "[[Embedded long quotes \\\". Escaped must stay! ]]")
+assert_str_round_trip( [[Long quoted string with a slash prior to quote \\\". ]])
+assert_str_round_trip( "[[Completely normal\n long quote. ]]")
+assert_str_round_trip( "\n[[Completely normal\n long quote. Except that we lead with a return! Tricky! ]]")
+assert_str_round_trip( '"balance [======[ doesn\'t ]====] mater when searching for embedded long-string quotes.')
+assert_str_round_trip( "Any\0 \t control character other than a return will be handled by the %q mechanism.")
+assert_str_round_trip( "This\tincludes\ttabs.")
+assert_str_round_trip( "But not returns.\n Returns are easier to see using long quotes.")
+assert_str_round_trip( "The \z 
+  escape does not trigger a control pattern, however.")
+
+assert_str_round_trip( "[==[If a string is long-quoted, escaped \\\" quotes have to stay! ]==]")
+assert_str_round_trip('"A quoted string looks like what?"')
+assert_str_round_trip( "'I think that it should be quoted, anyway.'")
+assert_str_round_trip( "[[Even if they're long quoted.]]") 
+
+assert_str_round_trip( "\"\\\"\\' pathalogical:starts with a quote ]\"\\']=]]==][[]]]=========]")
+assert_str_round_trip( "\\\"\\\"\\' pathalogical: quote is after this text with a quote ]\"\\']=]]==][[]]]=========]")
+assert_str_round_trip( "\\\"\\\"\\' pathalogical: quotes are all escaped. ]\\\"\\']=]]==][[]]]=========]")
+assert_str_round_trip( "")
+assert_str_round_trip( " ")
+assert_str_round_trip( "\n") --tricky.
+assert_str_round_trip( "[[")
+assert_str_round_trip( "''")
+assert_str_round_trip( '""')


### PR DESCRIPTION
Hey Steve,

I wanted to share this work with you, in case you found it useful. Please ignore/reject it if you don't find that it fits with Penlight's goals.

This pull request includes `stringx.quote_string` and changes to `pretty.write`. `quote_string` wraps a string such that reloading that string from a chunk of Lua code produces identical results:
```lua
mystr = "\n[[\n My tricky ]======] string.\n]]"
mystr2 = load("return " .. stringx.quote_string(mystr))()
assert(mystr == mystr2)
```
It provides the same facilities as `("%q"):format(str)`, plus:

* Uses long quotes when it finds a pattern that matches the long-quote pattern (begin or end, balance doesn't matter) or when it finds a `\n`.
* Adds an extra `\n` at the beginning, if found.
* When Long quotes are used, it always uses a number of `=` signs that is one greater than any long-quotes that are embedded into the string.

The second, and highly related, changes were to pretty.write:

* Uses `stringx.quote_string` instead of internal, literal methods.
* Adds a space in front and in back of string, when long strings are used for key values:

```lua
my_table = {
    [ [[
My crazy key
]] ] = "foo"
}
```

* Because of the first change, now embedded long-strings can round-trip through the pretty printer. Nested long-strings would not compile in Lua.

Finally, a small patch was added for pretty.number:

* Added check for Lua 5.3. Locally patched `tostring` so that it returns `123` instead of `123.0`. Without this patch, pretty.number was broken.


I also added tests and local function documentation, although this should be re-read and verified before accepting.