### PR TITLE
Improved detection of unsupported short flags

### DIFF
--- a/lua/pl/lapp.lua
+++ b/lua/pl/lapp.lua
@@ -332,7 +332,7 @@ function lapp.process_options_string(str,args)
                 if not eq then
                     parm = at(parmstr,1)
                     local flag = is_flag(parm)
-                    if flag.type ~= 'boolean' then
+                    if flag and flag.type ~= 'boolean' then
                     --if isdigit(at(parmstr,2)) then
                         -- a short option followed by a digit is an exception (for AW;))
                         -- push ahead into the arg array


### PR DESCRIPTION
Parsing of an unsupported short flag was failing with:

```
pl/lapp.lua:335: attempt to index local 'flag' (a nil value)
```

Example usage: `myscript.lua -ab`
Where `-a` is the unsupported flag.
