### PR TITLE
Allow XML tostring() function to customize the default prefacing with <?xml...>

### DIFF
--- a/lua/pl/xml.lua
+++ b/lua/pl/xml.lua
@@ -418,7 +418,7 @@ function _M.tostring(t,idn,indent, attr_indent, xml)
     if xml then
         if type(xml) == "string" then
             buf[1] = xml
-    	else
+        else
             buf[1] = "<?xml version='1.0'?>"
         end
     end

--- a/lua/pl/xml.lua
+++ b/lua/pl/xml.lua
@@ -411,11 +411,17 @@ end
 --- @param idn an initial indent (indents are all strings)
 --- @param indent an indent for each level
 --- @param attr_indent if given, indent each attribute pair and put on a separate line
---- @param xml force prefacing with <?xml...>
+--- @param xml force prefacing with default or custom <?xml...>
 --- @return a string representation
 function _M.tostring(t,idn,indent, attr_indent, xml)
     local buf = {};
-    if xml then buf[1] = "<?xml version='1.0'?>" end
+    if xml then
+        if type(xml) == "string" then
+            buf[1] = xml
+    	else
+            buf[1] = "<?xml version='1.0'?>"
+        end
+    end
     _dostring(t, buf, _dostring, xml_escape, nil,idn,indent, attr_indent);
     return t_concat(buf);
 end


### PR DESCRIPTION
This allows the user to specify a customized string for the XML prefacing. The function remains backwards compatible to existing users.

When specifying a string (instead of a boolean), the function will use that string instead of the default string. This allows to specify the encoding (e.g. UTF-8 and also beginning the string with BOM) and standalone etc. in the header.