### PR TITLE
lexer.lua: fix parsing block comments/string. fix hang on empty string.

### DIFF
--- a/lua/pl/lexer.lua
+++ b/lua/pl/lexer.lua
@@ -152,6 +152,7 @@ function lexer.scan (s,matches,filter,options)
         matches = plain_matches
     end
     local function lex ()
+        if type(s)=='string' and s=='' then return end
         local findres,i1,i2,idx,res1,res2,tok,pat,fun,capt
         local line = 1
         if file then s = file:read()..'\n' end


### PR DESCRIPTION
This pull request fixes lexer.scan hanging when the input is an empty string.
It also fixes the parser failing on block comments and strings when the block includes '=' between the brackets, like
--[===[
 block comment
]===]

[=[ a
block
string
]=]
