### PR TITLE
xml attribute underscore fix for simle parser

### DIFF
--- a/lua/pl/xml.lua
+++ b/lua/pl/xml.lua
@@ -554,12 +554,12 @@ function _M.basic_parse(s,all_text,html)
 
     local function parseargs(s)
       local arg = {}
-      s:gsub("([%w:]+)%s*=%s*([\"'])(.-)%2", function (w, _, a)
+      s:gsub("([%w:%-_]+)%s*=%s*([\"'])(.-)%2", function (w, _, a)
         if html then w = w:lower() end
         arg[w] = unescape(a)
       end)
       if html then
-        s:gsub("([%w:]+)%s*=%s*([^\"']+)%s*", function (w, a)
+        s:gsub("([%w:%-_]+)%s*=%s*([^\"']+)%s*", function (w, a)
           w = w:lower()
           arg[w] = unescape(a)
         end)

--- a/tests/test-xml.lua
+++ b/tests/test-xml.lua
@@ -491,7 +491,8 @@ xml.tostring(test_attrlist),
 "<AttrList Attr1='Value1' Attr2='Value2' Attr3='Value3'/>"
 )
 
----- commments ----
+
+-- commments
 str = [[
 <hello>
 <!-- any <i>momentous</i> stuff here -->
@@ -503,5 +504,21 @@ asserteq(xml.tostring(doc),[[
 <hello>
 dolly
 </hello>]])
+
+
+-- underscores and dashes in attributes
+
+str = [[
+<hello>
+    <tag my_attribute='my_value'>dolly</tag>
+</hello>
+]]
+doc = parse(str)
+
+print(doc)
+print(xml.tostring(doc))
+
+asserteq(xml.tostring(doc),[[
+<hello><tag my_attribute='my_value'>dolly</tag></hello>]])
 
 


### PR DESCRIPTION
Currently if you have an attribute name with an underscore, everything before the underscore is discarded during parsing.

```xml
<tag my_attribute='my_value'>Element contents</tag>
```

becomes

```xml
<tag attribute='my_value'>Element contents</tag>
```

This hopefully fixes this.