### PR TITLE
Added up-to-date scm-1 rockspec

### DIFF
--- a/penlight-scm-1.rockspec
+++ b/penlight-scm-1.rockspec
@@ -1,9 +1,8 @@
 package = "penlight"
-version = "1.1.0-3"
+version = "scm-1"
 
 source = {
-  dir = "penlight-1.1.0",
-  url = "http://stevedonovan.github.com/files/penlight-1.1.0-core.zip",
+  url = "git://github.com/stevedonovan/Penlight.git",
 }
 
 description = {
@@ -19,12 +18,13 @@ on tables and sequences.
 }
 
 dependencies = {
-  "luafilesystem",
+  "luafilesystem"
 }
 
 build = {
   type = "builtin",
   modules = {
+    ["pl"] = "lua/pl/init.lua",
     ["pl.strict"] = "lua/pl/strict.lua",
     ["pl.dir"] = "lua/pl/dir.lua",
     ["pl.operator"] = "lua/pl/operator.lua",
@@ -39,6 +39,7 @@ build = {
     ["pl.stringx"] = "lua/pl/stringx.lua",
     ["pl.lexer"] = "lua/pl/lexer.lua",
     ["pl.utils"] = "lua/pl/utils.lua",
+    ["pl.compat"] = "lua/pl/compat.lua",
     ["pl.sip"] = "lua/pl/sip.lua",
     ["pl.permute"] = "lua/pl/permute.lua",
     ["pl.pretty"] = "lua/pl/pretty.lua",
@@ -46,7 +47,6 @@ build = {
     ["pl.List"] = "lua/pl/List.lua",
     ["pl.data"] = "lua/pl/data.lua",
     ["pl.Date"] = "lua/pl/Date.lua",
-    ["pl.init"] = "lua/pl/init.lua",
     ["pl.luabalanced"] = "lua/pl/luabalanced.lua",
     ["pl.comprehension"] = "lua/pl/comprehension.lua",
     ["pl.path"] = "lua/pl/path.lua",
@@ -60,6 +60,9 @@ build = {
     ["pl.OrderedMap"] = "lua/pl/OrderedMap.lua",
     ["pl.Set"] = "lua/pl/Set.lua",
     ["pl.xml"] = "lua/pl/xml.lua",
-    ["pl.import_into"] = "lua/pl/import_into.lua",
+    ["pl.url"] = "lua/pl/url.lua",
+    ["pl.types"] = "lua/pl/types.lua",
+    ["pl.import_into"] = "lua/pl/import_into.lua"
   },
+  copy_directories = {"doc", "tests"}
 }


### PR DESCRIPTION
Fixes #137, obsoletes #96. The new scm-1 rockspec contains updated module list. There is no reason to keep old 1.1.0-3 rockspec, so I removed it. I'd recommend deleting old scm rockspecs from [luarocks](https://rocks.moonscript.org/modules/steved/penlight) and uploading this one instead, or it can be renamed to scm-3 and uploaded on top of old ones.