### PR TITLE
pl.stringx fixes

### DIFF
--- a/lua/pl/stringx.lua
+++ b/lua/pl/stringx.lua
@@ -83,12 +83,12 @@ function stringx.isupper(s)
 end
 
 --- does string start with the substring?
--- @string self the string
+-- @string s the string
 -- @string s2 a string
-function stringx.startswith(self,s2)
-    assert_string(1,self)
+function stringx.startswith(s,s2)
+    assert_string(1,s)
     assert_string(2,s2)
-    return find(self,s2,1,true) == 1
+    return find(s,s2,1,true) == 1
 end
 
 local function _find_all(s,sub,first,last)
@@ -127,20 +127,20 @@ end
 -- @section lists
 
 --- concatenate the strings using this string as a delimiter.
--- @string self the string
+-- @string s the string
 -- @param seq a table of strings or numbers
 -- @usage (' '):join {1,2,3} == '1 2 3'
-function stringx.join (self,seq)
-    assert_string(1,self)
-    return concat(seq,self)
+function stringx.join(s,seq)
+    assert_string(1,s)
+    return concat(seq,s)
 end
 
 --- break string into a list of lines
--- @string self the string
+-- @string s the string
 -- @param keepends (currently not used)
-function stringx.splitlines (self,keepends)
-    assert_string(1,self)
-    local res = usplit(self,'[\r\n]')
+function stringx.splitlines (s,keepends)
+    assert_string(1,s)
+    local res = usplit(s,'[\r\n]')
     -- we are currently hacking around a problem with utils.split (see stringx.split)
     if #res == 0 then res = {''} end
     return setmetatable(res,list_MT)
@@ -148,14 +148,13 @@ end
 
 --- split a string into a list of strings using a delimiter.
 -- @function split
--- @string self the string
+-- @string s the string
 -- @string[opt] re a delimiter (defaults to whitespace)
 -- @int[opt] n maximum number of results
 -- @usage #(('one two'):split()) == 2
 -- @usage ('one,two,three'):split(',') == List{'one','two','three'}
 -- @usage ('one,two,three'):split(',',2) == List{'one','two,three'}
-function stringx.split(self,re,n)
-    local s = self
+function stringx.split(s,re,n)
     local plain = true
     if not re then -- default spaces
         s = lstrip(s)
@@ -177,14 +176,14 @@ end
 --- replace all tabs in s with n spaces. If not specified, n defaults to 8.
 -- with 0.9.5 this now correctly expands to the next tab stop (if you really
 -- want to just replace tabs, use :gsub('\t','  ') etc)
--- @string self the string
+-- @string s the string
 -- @int n[opt=8] number of spaces to expand each tab
-function stringx.expandtabs(self,n)
-    assert_string(1,self)
+function stringx.expandtabs(s,n)
+    assert_string(1,s)
     n = n or 8
-    if not self:find '\n' then return tab_expand(self,n) end
+    if not s:find '\n' then return tab_expand(s,n) end
     local res,i = {},1
-    for line in stringx.lines(self) do
+    for line in stringx.lines(s) do
         res[i] = tab_expand(line,n)
         i = i + 1
     end
@@ -195,14 +194,14 @@ end
 -- @section find
 
 --- find index of first instance of sub in s from the left.
--- @string self the string
+-- @string s the string
 -- @string sub substring
 -- @int[opt] first first index
 -- @int[opt] last last index
-function stringx.lfind(self,sub,first,last)
-    assert_string(1,self)
+function stringx.lfind(s,sub,first,last)
+    assert_string(1,s)
     assert_string(2,sub)
-    local i1, i2 = find(self,sub,first,true)
+    local i1, i2 = find(s,sub,first,true)
 
     if i1 and (not last or i2 <= last) then
         return i1
@@ -212,14 +211,14 @@ function stringx.lfind(self,sub,first,last)
 end
 
 --- find index of first instance of sub in s from the right.
--- @string self the string
+-- @string s the string
 -- @string sub substring
 -- @int[opt] first first index
 -- @int[opt] last last index
-function stringx.rfind(self,sub,first,last)
-    assert_string(1,self)
+function stringx.rfind(s,sub,first,last)
+    assert_string(1,s)
     assert_string(2,sub)
-    return (_find_all(self,sub,first,last))
+    return (_find_all(s,sub,first,last))
 end
 
 --- replace up to n instances of old by new in the string s.
@@ -236,11 +235,11 @@ function stringx.replace(s,old,new,n)
 end
 
 --- count all instances of substring in string.
--- @string self the string
+-- @string s the string
 -- @string sub substring
-function stringx.count(self,sub)
-    assert_string(1,self)
-    local i,k = _find_all(self,sub,1)
+function stringx.count(s,sub)
+    assert_string(1,s)
+    local i,k = _find_all(s,sub,1)
     return k
 end
 
@@ -271,13 +270,13 @@ local function _just(s,w,ch,left,right)
 end
 
 --- left-justify s with width w.
--- @string self the string
+-- @string s the string
 -- @int w width of justification
 -- @string[opt=' '] ch padding character
-function stringx.ljust(self,w,ch)
-    assert_string(1,self)
+function stringx.ljust(s,w,ch)
+    assert_string(1,s)
     assert_arg(2,w,'number')
-    return _just(self,w,ch,true,false)
+    return _just(s,w,ch,true,false)
 end
 
 --- right-justify s with width w.
@@ -322,12 +321,12 @@ local function _strip(s,left,right,chrs)
 end
 
 --- trim any whitespace on the left of s.
--- @string self the string
+-- @string s the string
 -- @string[opt='%s'] chrs default any whitespace character,
 --  but can be a string of characters to be trimmed
-function stringx.lstrip(self,chrs)
-    assert_string(1,self)
-    return _strip(self,true,false,chrs)
+function stringx.lstrip(s,chrs)
+    assert_string(1,s)
+    return _strip(s,true,false,chrs)
 end
 lstrip = stringx.lstrip
 
@@ -341,25 +340,25 @@ function stringx.rstrip(s,chrs)
 end
 
 --- trim any whitespace on both left and right of s.
--- @string self the string
+-- @string s the string
 -- @string[opt='%s'] chrs default any whitespace character,
 --  but can be a string of characters to be trimmed
-function stringx.strip(self,chrs)
-    assert_string(1,self)
-    return _strip(self,true,true,chrs)
+function stringx.strip(s,chrs)
+    assert_string(1,s)
+    return _strip(s,true,true,chrs)
 end
 
 --- Partioning Strings
 -- @section partioning
 
 --- split a string using a pattern. Note that at least one value will be returned!
--- @string self the string
+-- @string s the string
 -- @string[opt='%s'] re a Lua string pattern (defaults to whitespace)
 -- @return the parts of the string
 -- @usage  a,b = line:splitv('=')
-function stringx.splitv (self,re)
-    assert_string(1,self)
-    return utils.splitv(self,re)
+function stringx.splitv(s,re)
+    assert_string(1,s)
+    return utils.splitv(s,re)
 end
 
 -- The partition functions split a string  using a delimiter into three parts:
@@ -375,58 +374,57 @@ local function _partition(p,delim,fn)
 end
 
 --- partition the string using first occurance of a delimiter
--- @string self the string
+-- @string s the string
 -- @string ch delimiter
 -- @return part before ch
 -- @return ch
 -- @return part after ch
-function stringx.partition(self,ch)
-    assert_string(1,self)
+function stringx.partition(s,ch)
+    assert_string(1,s)
     assert_nonempty_string(2,ch)
-    return _partition(self,ch,stringx.lfind)
+    return _partition(s,ch,stringx.lfind)
 end
 
 --- partition the string p using last occurance of a delimiter
--- @string self the string
+-- @string s the string
 -- @string ch delimiter
 -- @return part before ch
 -- @return ch
 -- @return part after ch
-function stringx.rpartition(self,ch)
-    assert_string(1,self)
+function stringx.rpartition(s,ch)
+    assert_string(1,s)
     assert_nonempty_string(2,ch)
-    return _partition(self,ch,stringx.rfind)
+    return _partition(s,ch,stringx.rfind)
 end
 
 --- return the 'character' at the index.
--- @string self the string
+-- @string s the string
 -- @int idx an index (can be negative)
 -- @return a substring of length 1 if successful, empty string otherwise.
-function stringx.at(self,idx)
-    assert_string(1,self)
+function stringx.at(s,idx)
+    assert_string(1,s)
     assert_arg(2,idx,'number')
-    return sub(self,idx,idx)
+    return sub(s,idx,idx)
 end
 
 --- Miscelaneous
 -- @section misc
 
 --- return an iterator over all lines in a string
--- @string self the string
+-- @string s the string
 -- @return an iterator
-function stringx.lines(self)
-    assert_string(1,self)
-    local s = self
+function stringx.lines(s)
+    assert_string(1,s)
     if not s:find '\n$' then s = s..'\n' end
     return s:gmatch('([^\n]*)\n')
 end
 
 --- iniital word letters uppercase ('title case').
 -- Here 'words' mean chunks of non-space characters.
--- @string self the string
+-- @string s the string
 -- @return a string with each word's first letter uppercase
-function stringx.title(self)
-    return (self:gsub('(%S)(%S*)',function(f,r)
+function stringx.title(s)
+    return (s:gsub('(%S)(%S*)',function(f,r)
         return f:upper()..r:lower()
     end))
 end
@@ -437,20 +435,20 @@ local elipsis = '...'
 local n_elipsis = #elipsis
 
 --- return a shorted version of a string.
--- @string self the string
+-- @string s the string
 -- @int sz the maxinum size allowed
 -- @bool tail true if we want to show the end of the string (head otherwise)
-function stringx.shorten(self,sz,tail)
-    if #self > sz then
+function stringx.shorten(s,sz,tail)
+    if #s > sz then
         if sz < n_elipsis then return elipsis:sub(1,sz) end
         if tail then
-            local i = #self - sz + 1 + n_elipsis
-            return elipsis .. self:sub(i)
+            local i = #s - sz + 1 + n_elipsis
+            return elipsis .. s:sub(i)
         else
-            return self:sub(1,sz-n_elipsis) .. elipsis
+            return s:sub(1,sz-n_elipsis) .. elipsis
         end
     end
-    return self
+    return s
 end
 
 --- Utility function that finds any patterns that match a long string's an open or close.

--- a/lua/pl/stringx.lua
+++ b/lua/pl/stringx.lua
@@ -167,27 +167,17 @@ function stringx.split(s,re,n)
 	return setmetatable(res,list_MT)
 end
 
-local function tab_expand (self,n)
-    return (gsub(self,'([^\t]*)\t', function(s)
-            return s..(' '):rep(n - #s % n)
-    end))
-end
-
---- replace all tabs in s with n spaces. If not specified, n defaults to 8.
+--- replace all tabs in s with tabsize spaces. If not specified, tabsize defaults to 8.
 -- with 0.9.5 this now correctly expands to the next tab stop (if you really
 -- want to just replace tabs, use :gsub('\t','  ') etc)
 -- @string s the string
--- @int n[opt=8] number of spaces to expand each tab
-function stringx.expandtabs(s,n)
+-- @int tabsize[opt=8] number of spaces to expand each tab
+function stringx.expandtabs(s,tabsize)
     assert_string(1,s)
-    n = n or 8
-    if not s:find '\n' then return tab_expand(s,n) end
-    local res,i = {},1
-    for line in stringx.lines(s) do
-        res[i] = tab_expand(line,n)
-        i = i + 1
-    end
-    return table.concat(res,'\n')
+    tabsize = tabsize or 8
+    return (s:gsub("([^\t\r\n]*)\t", function(before_tab)
+        return before_tab .. (" "):rep(tabsize - #before_tab % tabsize)
+    end))
 end
 
 --- Finding and Replacing

--- a/lua/pl/stringx.lua
+++ b/lua/pl/stringx.lua
@@ -180,12 +180,14 @@ end
 -- @section find
 
 local function _find_all(s,sub,first,last)
-    if sub == '' then return #s+1,#s end
+    first = first or 1
+    last = last or #s
+    if sub == '' then return last+1,last-first+1 end
     local i1,i2 = find(s,sub,first,true)
     local res
     local k = 0
     while i1 do
-        if last and i1 > last then break end
+        if last and i2 > last then break end
         res = i1
         k = k + 1
         i1,i2 = find(s,sub,i2+1,true)

--- a/lua/pl/stringx.lua
+++ b/lua/pl/stringx.lua
@@ -254,8 +254,8 @@ local function _just(s,w,ch,left,right)
         if not ch then ch = ' ' end
         local f1,f2
         if left and right then
-            local ln = ceil((w-n)/2)
-            local rn = w - n - ln
+            local rn = ceil((w-n)/2)
+            local ln = w - n - rn
             f1 = rep(ch,ln)
             f2 = rep(ch,rn)
         elseif right then

--- a/lua/pl/stringx.lua
+++ b/lua/pl/stringx.lua
@@ -151,6 +151,7 @@ end
 -- @usage ('one,two,three'):split(',') == List{'one','two','three'}
 -- @usage ('one,two,three'):split(',',2) == List{'one','two,three'}
 function stringx.split(s,re,n)
+    assert_string(1,s)
     local plain = true
     if not re then -- default spaces
         s = lstrip(s)
@@ -232,7 +233,8 @@ end
 -- @return result string
 function stringx.replace(s,old,new,n)
     assert_string(1,s)
-    assert_string(1,old)
+    assert_string(2,old)
+    assert_string(3,new)
     return (gsub(s,escape(old),new:gsub('%%','%%%%'),n))
 end
 
@@ -426,6 +428,7 @@ end
 -- @string s the string
 -- @return a string with each word's first letter uppercase
 function stringx.title(s)
+    assert_string(1,s)
     return (s:gsub('(%S)(%S*)',function(f,r)
         return f:upper()..r:lower()
     end))
@@ -445,6 +448,7 @@ local n_ellipsis = #ellipsis
 -- @usage ('1234567890'):shorten(8, true) == '...67890'
 -- @usage ('1234567890'):shorten(20) == '1234567890'
 function stringx.shorten(s,w,tail)
+    assert_string(1,s)
     if #s > w then
         if w < n_ellipsis then return ellipsis:sub(1,w) end
         if tail then
@@ -481,6 +485,7 @@ end
 -- @param s The string to be quoted.
 -- @return The quoted string.
 function stringx.quote_string(s)
+    assert_string(1,s)
     -- Find out if there are any embedded long-quote sequences that may cause issues.
     -- This is important when strings are embedded within strings, like when serializing.
     local equal_signs = has_lquote(s)

--- a/lua/pl/stringx.lua
+++ b/lua/pl/stringx.lua
@@ -198,11 +198,18 @@ end
 --- find index of first instance of sub in s from the left.
 -- @string self the string
 -- @string sub substring
--- @int[opt] first start index
-function stringx.lfind(self,sub,first)
+-- @int[opt] first first index
+-- @int[opt] last last index
+function stringx.lfind(self,sub,first,last)
     assert_string(1,self)
     assert_string(2,sub)
-    return (find(self,sub,first,true))
+    local i1, i2 = find(self,sub,first,true)
+
+    if i1 and (not last or i2 <= last) then
+        return i1
+    else
+        return nil
+    end
 end
 
 --- find index of first instance of sub in s from the right.

--- a/lua/pl/stringx.lua
+++ b/lua/pl/stringx.lua
@@ -431,21 +431,25 @@ end
 
 stringx.capitalize = stringx.title
 
-local elipsis = '...'
-local n_elipsis = #elipsis
+local ellipsis = '...'
+local n_ellipsis = #ellipsis
 
---- return a shorted version of a string.
+--- Return a shortened version of a string.
+-- Fits string within w characters. Removed characters are marked with ellipsis.
 -- @string s the string
--- @int sz the maxinum size allowed
+-- @int w the maxinum size allowed
 -- @bool tail true if we want to show the end of the string (head otherwise)
-function stringx.shorten(s,sz,tail)
-    if #s > sz then
-        if sz < n_elipsis then return elipsis:sub(1,sz) end
+-- @usage ('1234567890'):shorten(8) == '12345...'
+-- @usage ('1234567890'):shorten(8, true) == '...67890'
+-- @usage ('1234567890'):shorten(20) == '1234567890'
+function stringx.shorten(s,w,tail)
+    if #s > w then
+        if w < n_ellipsis then return ellipsis:sub(1,w) end
         if tail then
-            local i = #s - sz + 1 + n_elipsis
-            return elipsis .. s:sub(i)
+            local i = #s - w + 1 + n_ellipsis
+            return ellipsis .. s:sub(i)
         else
-            return s:sub(1,sz-n_elipsis) .. elipsis
+            return s:sub(1,w-n_ellipsis) .. ellipsis
         end
     end
     return s

--- a/lua/pl/stringx.lua
+++ b/lua/pl/stringx.lua
@@ -11,15 +11,14 @@
 local utils = require 'pl.utils'
 local string = string
 local find = string.find
-local type,setmetatable,getmetatable,ipairs,unpack = type,setmetatable,getmetatable,ipairs,utils.unpack
-local error,tostring = error,tostring
+local type,setmetatable,ipairs = type,setmetatable,ipairs
+local error = error
 local gsub = string.gsub
 local rep = string.rep
 local sub = string.sub
 local concat = table.concat
 local escape = utils.escape
 local ceil = math.ceil
-local _G = _G
 local assert_arg,usplit,list_MT = utils.assert_arg,utils.split,utils.stdmt.List
 local lstrip
 
@@ -502,7 +501,7 @@ function stringx.quote_string(s)
     return s
 end
 
-function stringx.import(dont_overload)
+function stringx.import()
     utils.import(stringx,string)
 end
 

--- a/lua/pl/stringx.lua
+++ b/lua/pl/stringx.lua
@@ -202,8 +202,7 @@ end
 function stringx.lfind(self,sub,i1)
     assert_string(1,self)
     assert_string(2,sub)
-    local idx = find(self,sub,i1,true)
-    if idx then return idx else return nil end
+    return (find(self,sub,i1,true))
 end
 
 --- find index of first instance of sub in s from the right.
@@ -214,8 +213,7 @@ end
 function stringx.rfind(self,sub,first,last)
     assert_string(1,self)
     assert_string(2,sub)
-    local idx = _find_all(self,sub,first,last)
-    if idx then return idx else return nil end
+    return (_find_all(self,sub,first,last))
 end
 
 --- replace up to n instances of old by new in the string s.
@@ -230,10 +228,6 @@ function stringx.replace(s,old,new,n)
     assert_string(1,s)
     assert_string(1,old)
     return (gsub(s,escape(old),new:gsub('%%','%%%%'),n))
-end
-
-local function copy(self)
-    return self..''
 end
 
 --- count all instances of substring in string.
@@ -267,7 +261,7 @@ local function _just(s,w,ch,left,right)
         end
         return f1..s..f2
     else
-        return copy(s)
+        return s
     end
 end
 

--- a/lua/pl/stringx.lua
+++ b/lua/pl/stringx.lua
@@ -41,49 +41,49 @@ local stringx = {}
 -- String Predicates
 -- @section predicates
 
---- does s only contain alphabetic characters?.
+--- does s only contain alphabetic characters?
 -- @string s a string
 function stringx.isalpha(s)
     assert_string(1,s)
     return find(s,'^%a+$') == 1
 end
 
---- does s only contain digits?.
+--- does s only contain digits?
 -- @string s a string
 function stringx.isdigit(s)
     assert_string(1,s)
     return find(s,'^%d+$') == 1
 end
 
---- does s only contain alphanumeric characters?.
+--- does s only contain alphanumeric characters?
 -- @string s a string
 function stringx.isalnum(s)
     assert_string(1,s)
     return find(s,'^%w+$') == 1
 end
 
---- does s only contain spaces?.
+--- does s only contain spaces?
 -- @string s a string
 function stringx.isspace(s)
     assert_string(1,s)
     return find(s,'^%s+$') == 1
 end
 
---- does s only contain lower case characters?.
+--- does s only contain lower case characters?
 -- @string s a string
 function stringx.islower(s)
     assert_string(1,s)
     return find(s,'^[%l%s]+$') == 1
 end
 
---- does s only contain upper case characters?.
+--- does s only contain upper case characters?
 -- @string s a string
 function stringx.isupper(s)
     assert_string(1,s)
     return find(s,'^[%u%s]+$') == 1
 end
 
---- does string start with the substring?.
+--- does string start with the substring?
 -- @string self the string
 -- @string s2 a string
 function stringx.startswith(self,s2)
@@ -151,7 +151,7 @@ end
 -- @function split
 -- @string self the string
 -- @string[opt] re a delimiter (defaults to whitespace)
--- @int n maximum number of results
+-- @int[opt] n maximum number of results
 -- @usage #(('one two'):split()) == 2
 -- @usage ('one,two,three'):split(',') == List{'one','two','three'}
 -- @usage ('one,two,three'):split(',',2) == List{'one','two,three'}
@@ -179,7 +179,7 @@ end
 -- with 0.9.5 this now correctly expands to the next tab stop (if you really
 -- want to just replace tabs, use :gsub('\t','  ') etc)
 -- @string self the string
--- @int n number of spaces to expand each tab, (default 8)
+-- @int n[opt=8] number of spaces to expand each tab
 function stringx.expandtabs(self,n)
     assert_string(1,self)
     n = n or 8
@@ -198,18 +198,18 @@ end
 --- find index of first instance of sub in s from the left.
 -- @string self the string
 -- @string sub substring
--- @int  i1 start index
-function stringx.lfind(self,sub,i1)
+-- @int[opt] first start index
+function stringx.lfind(self,sub,first)
     assert_string(1,self)
     assert_string(2,sub)
-    return (find(self,sub,i1,true))
+    return (find(self,sub,first,true))
 end
 
 --- find index of first instance of sub in s from the right.
 -- @string self the string
 -- @string sub substring
--- @int first first index
--- @int last last index
+-- @int[opt] first first index
+-- @int[opt] last last index
 function stringx.rfind(self,sub,first,last)
     assert_string(1,self)
     assert_string(2,sub)
@@ -223,7 +223,6 @@ end
 -- @string new the substitution
 -- @int[opt] n optional maximum number of substitutions
 -- @return result string
--- @return the number of substitutions
 function stringx.replace(s,old,new,n)
     assert_string(1,s)
     assert_string(1,old)
@@ -268,7 +267,7 @@ end
 --- left-justify s with width w.
 -- @string self the string
 -- @int w width of justification
--- @string[opt=''] ch padding character
+-- @string[opt=' '] ch padding character
 function stringx.ljust(self,w,ch)
     assert_string(1,self)
     assert_arg(2,w,'number')
@@ -278,7 +277,7 @@ end
 --- right-justify s with width w.
 -- @string s the string
 -- @int w width of justification
--- @string[opt=''] ch padding character
+-- @string[opt=' '] ch padding character
 function stringx.rjust(s,w,ch)
     assert_string(1,s)
     assert_arg(2,w,'number')
@@ -288,7 +287,7 @@ end
 --- center-justify s with width w.
 -- @string s the string
 -- @int w width of justification
--- @string[opt=''] ch padding character
+-- @string[opt=' '] ch padding character
 function stringx.center(s,w,ch)
     assert_string(1,s)
     assert_arg(2,w,'number')
@@ -318,7 +317,7 @@ end
 
 --- trim any whitespace on the left of s.
 -- @string self the string
--- @string[opt='%x'] chrs default any whitespace character,
+-- @string[opt='%s'] chrs default any whitespace character,
 --  but can be a string of characters to be trimmed
 function stringx.lstrip(self,chrs)
     assert_string(1,self)
@@ -328,7 +327,7 @@ lstrip = stringx.lstrip
 
 --- trim any whitespace on the right of s.
 -- @string s the string
--- @string[opt='%x'] chrs default any whitespace character,
+-- @string[opt='%s'] chrs default any whitespace character,
 --  but can be a string of characters to be trimmed
 function stringx.rstrip(s,chrs)
     assert_string(1,s)
@@ -337,7 +336,7 @@ end
 
 --- trim any whitespace on both left and right of s.
 -- @string self the string
--- @string[opt='%x'] chrs default any whitespace character,
+-- @string[opt='%s'] chrs default any whitespace character,
 --  but can be a string of characters to be trimmed
 function stringx.strip(self,chrs)
     assert_string(1,self)
@@ -406,10 +405,10 @@ end
 --- Miscelaneous
 -- @section misc
 
---- return an interator over all lines in a string
+--- return an iterator over all lines in a string
 -- @string self the string
 -- @return an iterator
-function stringx.lines (self)
+function stringx.lines(self)
     assert_string(1,self)
     local s = self
     if not s:find '\n$' then s = s..'\n' end

--- a/tests/test-pylib.lua
+++ b/tests/test-pylib.lua
@@ -56,7 +56,7 @@ s = '  here we go    '
 asserteq (s:lstrip() , 'here we go    ')
 asserteq (s:rstrip() , '  here we go')
 asserteq (s:strip() , 'here we go')
-asserteq (('hello'):center(20,'+') , '++++++++hello+++++++')
+asserteq (('hello'):center(20,'+') , '+++++++hello++++++++')
 
 t = Template('${here} is the $answer')
 asserteq(t:substitute {here = 'one', answer = 'two'} , 'one is the two')

--- a/tests/test-stringx.lua
+++ b/tests/test-stringx.lua
@@ -324,6 +324,7 @@ assert_str_round_trip( "[==[If a string is long-quoted, escaped \\\" quotes have
 assert_str_round_trip('"A quoted string looks like what?"')
 assert_str_round_trip( "'I think that it should be quoted, anyway.'")
 assert_str_round_trip( "[[Even if they're long quoted.]]")
+assert_str_round_trip( "]=]==]")
 
 assert_str_round_trip( "\"\\\"\\' pathalogical:starts with a quote ]\"\\']=]]==][[]]]=========]")
 assert_str_round_trip( "\\\"\\\"\\' pathalogical: quote is after this text with a quote ]\"\\']=]]==][[]]]=========]")
@@ -331,6 +332,9 @@ assert_str_round_trip( "\\\"\\\"\\' pathalogical: quotes are all escaped. ]\\\"\
 assert_str_round_trip( "")
 assert_str_round_trip( " ")
 assert_str_round_trip( "\n") --tricky.
+assert_str_round_trip( "\r")
+assert_str_round_trip( "\r\n")
+assert_str_round_trip( "\r1\n")
 assert_str_round_trip( "[[")
 assert_str_round_trip( "''")
 assert_str_round_trip( '""')

--- a/tests/test-stringx.lua
+++ b/tests/test-stringx.lua
@@ -177,7 +177,7 @@ asserteq(T(stringx.center('', 0)), T(''))
 asserteq(T(stringx.center('', 1)), T(' '))
 asserteq(T(stringx.center('', 2)), T('  '))
 asserteq(T(stringx.center('a', 1)), T('a'))
-asserteq(T(stringx.center('a', 2)), T(' a'))
+asserteq(T(stringx.center('a', 2)), T('a '))
 asserteq(T(stringx.center('a', 3)), T(' a '))
 
 

--- a/tests/test-stringx.lua
+++ b/tests/test-stringx.lua
@@ -114,9 +114,14 @@ asserteq(T(stringx.lfind('abcbcbbc', 'bc', nil, 5)), T(2))
 -- rfind
 asserteq(T(stringx.rfind('', '')), T(1))
 asserteq(T(stringx.rfind('ab', '')), T(3))
+asserteq(T(stringx.rfind('abc', 'cd')), T(nil))
 asserteq(T(stringx.rfind('abcbc', 'bc')), T(4))
 asserteq(T(stringx.rfind('abcbcb', 'bc')), T(4))
 asserteq(T(stringx.rfind('ab..cd', '.')), T(4)) -- pattern char
+asserteq(T(stringx.rfind('abcbcbbc', 'bc', 3)), T(7))
+asserteq(T(stringx.rfind('abcbcbbc', 'bc', 3, 4)), T(nil))
+asserteq(T(stringx.rfind('abcbcbbc', 'bc', 3, 5)), T(4))
+asserteq(T(stringx.rfind('abcbcbbc', 'bc', nil, 5)), T(4))
 
 -- replace
 asserteq(T(stringx.replace('', '', '')), T(''))

--- a/tests/test-stringx.lua
+++ b/tests/test-stringx.lua
@@ -101,6 +101,11 @@ asserteq(T(stringx.lfind('a', '')), T(1))
 asserteq(T(stringx.lfind('ab', 'b')), T(2))
 asserteq(T(stringx.lfind('abc', 'cd')), T(nil))
 asserteq(T(stringx.lfind('abcbc', 'bc')), T(2))
+asserteq(T(stringx.lfind('ab..cd', '.')), T(3)) -- pattern char
+asserteq(T(stringx.lfind('abcbcbbc', 'bc', 3)), T(4))
+asserteq(T(stringx.lfind('abcbcbbc', 'bc', 3, 4)), T(nil))
+asserteq(T(stringx.lfind('abcbcbbc', 'bc', 3, 5)), T(4))
+asserteq(T(stringx.lfind('abcbcbbc', 'bc', nil, 5)), T(2))
 
 -- rfind
 asserteq(T(stringx.rfind('', '')), T(1))

--- a/tests/test-stringx.lua
+++ b/tests/test-stringx.lua
@@ -52,6 +52,10 @@ asserteq(T(startswith('abc', 'bc')), T(false)) -- off by one
 asserteq(T(startswith('abc', '.')), T(false)) -- Lua pattern char
 asserteq(T(startswith('a\0bc', 'a\0b')), T(true)) -- '\0'
 
+asserteq(startswith('abcfoo',{'abc','def'}),true)
+asserteq(startswith('deffoo',{'abc','def'}),true)
+asserteq(startswith('cdefoo',{'abc','def'}),false)
+
 
 -- endswith
 -- http://snippets.luacode.org/sputnik.lua?p=snippets/Check_string_ends_with_other_string_74


### PR DESCRIPTION
This PR fixes some tiny bugs, removes some unused things, adds some functionality for consistency (`last` argument for `lfind`, array of prefixes as argument for `startswith`), fixes documentation, adds tests, etc. See diffs and commit messages for details.

It seems there are some issues with various functions for splitting, and I'm not sure how to fix them as intended behaviour deviates from similar functions in Python's standard library. For instance, `stringx.splitlines` deliberately returns {""} when splitting an empty string ([link](https://github.com/stevedonovan/Penlight/blob/294522658bbc14ee6dc68938975c473f04b5dfd2/lua/pl/stringx.lua#L146)) which contradicts Python's docs: [2.7](https://docs.python.org/2/library/stdtypes.html#str.splitlines) [3.4](https://docs.python.org/3/library/stdtypes.html#bytes.splitlines).