### PR TITLE
Add travis-ci testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+sudo: false
+
+env:
+  - LUA="lua 5.1"
+  - LUA="lua 5.2"
+  - LUA="lua 5.3"
+  - LUA="luajit 2.0"
+
+before_install:
+  - pip install hererocks
+  - hererocks here -r^ --$LUA
+  - export PATH=$PATH:$PWD/here/bin
+
+install:
+  - luarocks make
+
+script:
+  - lua tests/tests.run


### PR DESCRIPTION
Added a simple config for [Travis-Ci](https://travis-ci.org/) that runs tests under Lua 5.1-5.3 and LuaJIT 2.0 using their container infrastructure (no `sudo` used). You'll still have to log into travis-ci site and enable testing for this repo, but after that tests will be executed automatically for each push, [like this](https://travis-ci.org/mpeterv/Penlight/builds/79621620).