### PR TITLE
Fix pl.template error for large templates

### DIFF
--- a/lua/pl/template.lua
+++ b/lua/pl/template.lua
@@ -30,31 +30,45 @@
 
 local utils = require 'pl.utils'
 
+local append,format,strsub,strfind = table.insert,string.format,string.sub,string.find
+
+-- If expression nesting is too deep, loading will result in
+-- "chunk has too many syntax levels " error.
+-- By default the limit is 200, but it can be also consumed by nested blocks
+-- added in raw Lua code, so it's better to stop earlier.
+local max_concatenations = 100
+
+local function parseDollarParen(pieces, chunk, exec_pat)
+    local concatenations = 0
+    local s = 1
+    for term, executed, e in chunk:gmatch(exec_pat) do
+        executed = '('..strsub(executed,2,-2)..')'
+        concatenations = concatenations + 2
+        if concatenations > max_concatenations then
+            append(pieces, format("%q)_put((%s or '')..",
+                strsub(chunk,s, term - 1), executed))
+            concatenations = 1
+        else
+            append(pieces, format("%q..(%s or '')..",
+                strsub(chunk,s, term - 1), executed))
+        end
+        s = e
+    end
+    append(pieces, format("%q", strsub(chunk,s)))
+end
 
 local function parseHashLines(chunk,brackets,esc)
-    local append,format,strsub,strfind = table.insert,string.format,string.sub,string.find
     local exec_pat = "()$(%b"..brackets..")()"
-
-    local function parseDollarParen(pieces, chunk, s, e)
-        local s = 1
-        for term, executed, e in chunk:gmatch (exec_pat) do
-            executed = '('..strsub(executed,2,-2)..')'
-            append(pieces,
-              format("%q..(%s or '')..",strsub(chunk,s, term - 1), executed))
-            s = e
-        end
-        append(pieces, format("%q", strsub(chunk,s)))
-    end
 
     local esc_pat = esc.."+([^\n]*\n?)"
     local esc_pat1, esc_pat2 = "^"..esc_pat, "\n"..esc_pat
     local  pieces, s = {"return function(_put) ", n = 1}, 1
     while true do
-        local ss, e, lua = strfind (chunk,esc_pat1, s)
+        local ss, e, lua = strfind(chunk,esc_pat1, s)
         if not e then
             ss, e, lua = strfind(chunk,esc_pat2, s)
             append(pieces, "_put(")
-            parseDollarParen(pieces, strsub(chunk,s, ss))
+            parseDollarParen(pieces, strsub(chunk,s, ss), exec_pat)
             append(pieces, ")")
             if not e then break end
         end

--- a/tests/test-substitute.lua
+++ b/tests/test-substitute.lua
@@ -37,5 +37,5 @@ asserteq(subst([[
     cout << obj.gamma << endl;
 ]])
 
-
-
+-- handle templates with a lot of substitutions
+asserteq(subst(("$(x)\n"):rep(300), {x = "y"}), ("y\n"):rep(300))


### PR DESCRIPTION
Count expression nesting level when emitting code for a template, break up concatenations when it gets too large.