### PR TITLE
Add coverage gathering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ before_install:
 
 install:
   - luarocks make
+  - luarocks install luacov-coveralls
 
 script:
-  - lua tests/tests.run
+  - lua tests/tests.run --luacov
+
+after_success:
+  - mv tests/luacov.stats.out . && luacov-coveralls -c tests/.luacov

--- a/tests/.luacov
+++ b/tests/.luacov
@@ -1,0 +1,6 @@
+return {
+  modules = {
+    ["pl"] = "lua/pl/init.lua",
+    ["pl.*"] = "lua"
+  }
+}

--- a/tests/tests.run
+++ b/tests/tests.run
@@ -2,15 +2,12 @@
 require 'pl'
 local lfs = require 'lfs'
 
-local function quote_if_needed (s)
-    if s:match '%s' then
-        s = '"'..s..'"'
-    end
-    return s
-end
-
 -- get the Lua command-line used to invoke this script
 local cmd = app.lua()
+
+if arg[1] == "--luacov" then
+    cmd = cmd..' -lluacov'
+end
 
 local D = path.dirname(arg[0])
 print('Running tests in',D)
@@ -28,6 +25,3 @@ end
 
 lfs.chdir(D)
 do_lua_files()
-
-
-


### PR DESCRIPTION
Added automated coverage gathering using luacov and luacov-coveralls. Similarly to Travis, you'll have to sign in to https://coveralls.io and enable it. It'll look like this: https://coveralls.io/github/mpeterv/Penlight