### PR TITLE
Fix option name used instead of option value in lapp

### DIFF
--- a/lua/pl/lapp.lua
+++ b/lua/pl/lapp.lua
@@ -373,6 +373,7 @@ function lapp.process_options_string(str,args)
             if not val then
                 i = i + 1
                 val = arg[i]
+                theArg = val
             end
             lapp.assert(val,parm.." was expecting a value")
         else -- toggle boolean flags (usually false -> true)

--- a/tests/test-lapp.lua
+++ b/tests/test-lapp.lua
@@ -47,15 +47,32 @@ check(simple,
     {'-o','in'},
     {quiet=false,p=false,o='in',input='<file>'})
 
+-- Check lapp.callback.
+local calls = {}
+function lapp.callback(param, arg)
+    table.insert(calls, {param, arg})
+end
 check(simple,
     {'-o','help','-q','test-lapp.lua'},
     {quiet=true,p=false,o='help',input='<file>',input_name='test-lapp.lua'})
+test.asserteq(calls, {
+    {'o', 'help'},
+    {'quiet', '-q'},
+    {'input', 'test-lapp.lua'}
+})
+lapp.callback = nil
 
 local longs = [[
     --open (string)
 ]]
 
 check(longs,{'--open','folder'},{open='folder'})
+
+local long_file = [[
+    --open (default stdin)
+]]
+
+check(long_file,{'--open','test-lapp.lua'},{open='<file>',open_name='test-lapp.lua'})
 
 local extras1 = [[
     <files...> (string) A bunch of files


### PR DESCRIPTION
When shifting arguments to get a value of an option, update variable holding current argument. Fixes #160 plus incorrect file name assigned to `<long_option>_name`, see two new test cases.