### PR TITLE
Update pretty.lua

### DIFF
--- a/lua/pl/pretty.lua
+++ b/lua/pl/pretty.lua
@@ -226,7 +226,9 @@ function pretty.write (tbl,space,not_clever)
                     used[i] = true
                 end
             end
-            for key,val in pairs(t) do
+            local iterator = t.iter
+            if iterator == nil then iterator = pairs end
+            for key,val in iterator(t) do
                 local numkey = type(key) == 'number'
                 if not_clever then
                     key = tostring(key)


### PR DESCRIPTION
Support for OrderedMap or other tables that has an iter() method to print in order using Lua 5.1.

It was surprising that OrderedMap did not pretty.write() in order when using Lua 5.1. If there is a better way to support this, that is fine too.