### PR TITLE
pl.dir.execute_command: delete tmpfile after use

### DIFF
--- a/lua/pl/dir.lua
+++ b/lua/pl/dir.lua
@@ -125,8 +125,11 @@ local function execute_command(cmd,parms)
     cmd = cmd..' '..parms..err..cmd_tmpfile
     local ret = utils.execute(cmd)
     if not ret then
-        return false,(utils.readfile(cmd_tmpfile):gsub('\n(.*)',''))
+        local err = (utils.readfile(cmd_tmpfile):gsub('\n(.*)',''))
+        remove(cmd_tmpfile)
+        return false,err
     else
+        remove(cmd_tmpfile)
         return true
     end
 end


### PR DESCRIPTION
I've noticed my program always leaves a /tmp/lua_* file behind, and I've finally been able to trace it to a pl.file.copy i'm running. On my Linux system, this function executes a "cp" shell command though the local function execute_command in the dir module. This function creates a path.tmpname to store the output of the command in case of error, but this file is never deleted. This PR deletes it.