### PR TITLE
tablex.pairmap: append if key already exists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
   -  Fixed utils.execute returning different values for Lua 5.1 and Lua 5.2
   - Issue #97; fixed attempt to put a month into a day
   -  problem with tablex.count_map with custom comparison
+  - tablex.pairmap overwrites result if key already exists; instead, upon detection that key already exists
+	for a returned value, we modify the key's value to be a table and insert values into that table
 
 ### Features
 

--- a/lua/pl/tablex.lua
+++ b/lua/pl/tablex.lua
@@ -473,8 +473,8 @@ end
 
 --- call the function with the key and value pairs from a table.
 -- The function can return a value and a key (note the order!). If both
--- are not nil, then this pair is inserted into the result. If only value is not nil, then
--- it is appended to the result.
+-- are not nil, then this pair is inserted into the result: if the key already exists, we convert the value for that
+-- key into a table and append into it. If only value is not nil, then it is appended to the result.
 -- @within MappingAndFiltering
 -- @func fun A function which will be passed each key and value as arguments, plus any extra arguments to pairmap.
 -- @tab t A table
@@ -488,7 +488,15 @@ function tablex.pairmap(fun,t,...)
     for k,v in pairs(t) do
         local rv,rk = fun(k,v,...)
         if rk then
-            res[rk] = rv
+			if res[rk] then
+				if type(res[rk]) == 'table' then
+					table.insert(res[rk],rv)
+				else
+					res[rk] = {res[rk], rv}
+				end
+			else
+            	res[rk] = rv
+			end
         else
             res[#res+1] = rv
         end

--- a/tests/test-tablex.lua
+++ b/tests/test-tablex.lua
@@ -171,7 +171,10 @@ asserteq(difference({a = true},{b = true}),{a=true})
 -- symmetric difference
 asserteq(difference({a = true},{b = true},true),{a=true,b=true})
 
-
+--basic index_map test
+asserteq(index_map({10,20,30}), {[10]=1,[20]=2,[30]=3})
+--test that repeated values return multiple indices
+asserteq(index_map({10,20,30,30,30}), {[10]=1,[20]=2,[30]={3,4,5}})
 
 
 


### PR DESCRIPTION
Previously, a call to tablex.pairmap would overwrite values if a value
was returned for a key that already had a value. Now, when a value is
returned for a key that already exists, we convert the key's value into
a table containing the original value and append the new value being
returned into that table.  Running test-tablex.lua passed after this
modification.

Here's the motivating use case that will make this clearer:

trial_ids = {"001","001","002","002"}

--I'd like a list of which trials have ids 1 and which trials have ids 2, so I tried
--calling tablex.index_map:

trial_nums_for_ids = tablex.index_map(trial_ids)

--but I got this output (which occurs because index_map calls tablex.pairmap,
--which overwrites the value associated with a key whenever a value is returned
--for an existing key)
{
001: 2
002: 4
}

--my changes to pairmap produce the following desired output:
{["001"] = {1,2}, ["002"] = {3,4}}
