### PR TITLE
Fix error in OrderedMap.set when key is a method name

### DIFF
--- a/lua/pl/OrderedMap.lua
+++ b/lua/pl/OrderedMap.lua
@@ -70,9 +70,9 @@ end
 -- @param val the value
 -- @return the map
 function OrderedMap:set (key,val)
-    if self[key] == nil and val ~= nil then -- new key
-       self._keys:append(key) -- we keep in order
-       rawset(self,key,val)  -- don't want to provoke __newindex!
+    if rawget(self, key) == nil and val ~= nil then -- new key
+        self._keys:append(key) -- we keep in order
+        rawset(self,key,val)  -- don't want to provoke __newindex!
     else -- existing key-value pair
         if val == nil then
             self._keys:remove_value(key)

--- a/tests/test-set.lua
+++ b/tests/test-set.lua
@@ -118,6 +118,10 @@ asserteq2 ('one',1,fn())
 asserteq2 ('two',2,fn())
 asserteq2 ('three',3,fn())
 
+-- Keys overriding methods can be used.
+m:set('set', 4)
+asserteq(m:values(),List{1,2,3,4})
+
 o1 = OrderedMap  {{z=2},{beta=1},{name='fred'}}
 asserteq(tostring(o1),'{z=2,beta=1,name="fred"}')
 


### PR DESCRIPTION
Use raw access to check if a key exists, so that keys naming OrderedMap methods are handled correctly.
