### PR TITLE
utils.executeex() fails on Windows with MSVC14

### DIFF
--- a/lua/pl/utils.lua
+++ b/lua/pl/utils.lua
@@ -232,7 +232,7 @@ function utils.executeex(cmd, bin)
     local outfile = os.tmpname()
     local errfile = os.tmpname()
 
-    if utils.dir_separator == '\\' then
+    if utils.dir_separator == '\\' and not outfile:find(':') then
         outfile = os.getenv('TEMP')..outfile
         errfile = os.getenv('TEMP')..errfile
     end


### PR DESCRIPTION
When Lua is compiled with MSVC14 (Visual Studio 2015), utils.executeex() always fails with “The filename, directory name, or volume label syntax is incorrect”. This is because on that C runtime library, os.tmpname() returns a full path (something like “C:\Users\Walther\AppData\Local\Temp\s290.2”) and the code that prepends the value of the TEMP environment variable in an attempt to deal with the output of older C runtime libraries (something like “\s558.2” on MSVC10, I didn’t try any others) creates an invalid path due to the ‘:’ in the duplicated drive letter.

Both cases are observed on the same Windows 7 system with Lua 5.2.3.

The attached commit detects the full path and skips the workaround, making the function work on both versions.

Probably related to #187 but I didn’t check in detail.