### PR TITLE
Fix path.normpath

### DIFF
--- a/tests/test-path.lua
+++ b/tests/test-path.lua
@@ -36,25 +36,32 @@ asserteq(norm '/a/fred/../b',p)
 asserteq(norm '/a//b',p)
 
 function testnorm(p1,p2)
-    asserteq(p2,norm(p1):gsub('\\','/'))
+    asserteq(norm(p1):gsub('\\','/'), p2)
 end
 
-testnorm('a/b/..','a/')
+testnorm('a/b/..','a')
 testnorm('a/b/../..','.')
 testnorm('a/b/../c/../../d','d')
-testnorm('a/.','a/.')
-testnorm('a/./','a/')
+testnorm('a/.','a')
+testnorm('a/./','a')
 testnorm('a/b/.././..','.')
 testnorm('../../a/b','../../a/b')
-testnorm('../../a/b/../../','../../')
+testnorm('../../a/b/../../','../..')
 testnorm('../../a/b/../c','../../a/c')
 testnorm('./../../a/b/../c','../../a/c')
+testnorm('a/..b', 'a/..b')
+testnorm('./a', 'a')
+testnorm('a/.', 'a')
+testnorm('a/', 'a')
+testnorm('/a', '/a')
+testnorm('//a', '//a')
+testnorm('///a', '/a')
 
 if path.is_windows then
   asserteq(norm [[\a\.\b]],p)
   -- UNC paths
   asserteq(norm [[\\bonzo\..\dog]], [[\\dog]])
-  asserteq(norm [[\\?\c:\bonzo\dog\.\]],[[\\?\c:\bonzo\dog\]])
+  asserteq(norm [[\\?\c:\bonzo\dog\.\]],[[\\?\c:\bonzo\dog]])
 end
 
 asserteq(norm '1/2/../3/4/../5',norm '1/3/5')


### PR DESCRIPTION
Rewrite path.normpath to first split out path anchor (drive or UNC path start or '/', '//' or '\') and then iterate over parts of remaining relative path.

This fixes issues with normpath not working correctly (comparing to Python's os.path.normpath) in these cases:

* When a path part starts with '..':
    * `os.path.normpath("A/..B") == "A/..B"`
    * `pl.path.normpath("A/..B") == "B"`
* When a path starts with './':
    * `os.path.normpath("./A") == "A"`
    * `pl.path.normpath("./A") == "./A"`
* When a path ends with '/.':
    * `os.path.normpath("A/.") == "A"`
    * `pl.path.normpath("A/.") == "A/."`
* When a path ends with '/':
    * `os.path.normpath("A/") == "A"`
    * `pl.path.normpath("A/") == "A/"`
* When a path starts with '//':
    * `os.path.normpath("//") == "//"`
    * `pl.path.normpath("//") == "/"`

I wrote [this script](https://gist.github.com/mpeterv/5f5bbd8e00910e679c0ec19c9b4110c0) to find these mismatches. After this commit the only category of mismatches is paths starting with '/..': Python collapses that to '/'.

On Windows this commit fixes `"C:\.."` being normalized to `"."`. Also fixes #184.