### PR TITLE
Return a function from utils.memoize instead of a table

### DIFF
--- a/lua/pl/utils.lua
+++ b/lua/pl/utils.lua
@@ -253,14 +253,15 @@ end
 -- @param func a function of at least one argument
 -- @return a function with at least one argument, which is used as the key.
 function utils.memoize(func)
-    return setmetatable({}, {
-        __index = function(self, k, ...)
-            local v = func(k,...)
-            self[k] = v
-            return v
-        end,
-        __call = function(self, k) return self[k] end
-    })
+    local cache = {}
+    return function(k)
+        local res = cache[k]
+        if res == nil then
+            res = func(k)
+            cache[k] = res
+        end
+        return res
+    end
 end
 
 


### PR DESCRIPTION
First, documentation says it should return a function; second,
attempting to serialize memoization table may result in an error:
on Lua 5.3 ipairs() uses __index metamethod which may not work
if the function doesn't take numbers as arguments.

Fixes pl.pretty.write(_G) crashing on Lua 5.3.