### PR TITLE
Fix the case where "s" is empty string in dedent()

### DIFF
--- a/lua/pl/text.lua
+++ b/lua/pl/text.lua
@@ -65,7 +65,7 @@ end
 function text.dedent (s)
     assert_arg(1,s,'string')
     local sl = split(s,'\n')
-    local i1,i2 = sl[1]:find('^%s*')
+    local i1,i2 = (#sl>0 and sl[1] or ''):find('^%s*')
     sl = imap(string.sub,sl,i2+1)
     return concat(sl,'\n')..'\n'
 end


### PR DESCRIPTION
Today, when I tried to build documentation in "doc" folder of ldoc using ldoc itself, I found that error:
```
reading configuration from config.ld
/var/tmp/portage/dev-lua/ldoc-9999/work/all/ldoc-9999/ldoc.lua:840: internal LDoc error
/usr/share/lua/5.1/pl/text.lua:68: attempt to index a nil value
stack traceback:
        /usr/share/lua/5.1/pl/text.lua:68: in function 'dedent'
        ...dev-lua/ldoc-9999/work/all/ldoc-9999/doc/../ldoc/doc.lua:627: in function 'finish'
        ...dev-lua/ldoc-9999/work/all/ldoc-9999/doc/../ldoc/doc.lua:237: in function 'finish'
        ...v-lua/ldoc-9999/work/all/ldoc-9999/doc/../ldoc/parse.lua:424: in function <...v-lua/ldoc-9999/work/all/ldoc-9999/doc/../ldoc/parse.lua:424>
        [C]: in function 'xpcall'
        ...v-lua/ldoc-9999/work/all/ldoc-9999/doc/../ldoc/parse.lua:424: in function 'file'
        ../ldoc.lua:414: in function 'process_file'
        ../ldoc.lua:505: in main chunk
        [C]: at 0x00404cd0
```
after adding debug canaries into `pl/text.lua` I found that it is due to the fact of `s` being an empty string.
So, that change is fixed it.