### PR TITLE
Fix number formatting in pl.pretty

### DIFF
--- a/lua/pl/pretty.lua
+++ b/lua/pl/pretty.lua
@@ -269,12 +269,9 @@ end
 
 local memp,nump = {'B','KiB','MiB','GiB'},{'','K','M','B'}
 
-local comma
-function comma (val)
+local function comma (val)
     local thou = math.floor(val/1000)
-    --AAS
-    if thou > 0 then return comma(tostring(thou))..','.. tostring(val % 1000)
-    -- if thou > 0 then return comma(thou)..','..(val % 1000)
+    if thou > 0 then return comma(thou)..','.. tostring(val % 1000)
     else return tostring(val) end
 end
 

--- a/tests/test-pretty.lua
+++ b/tests/test-pretty.lua
@@ -84,35 +84,11 @@ t2 = {}
 t1[1],t1[2] = t2,t2
 asserteq( pretty.write(t1,""), [[{{},{}}]] )
 
-function testm(x,s)
-  asserteq(pretty.number(x,'M'),s)
+-- Check number formatting
+asserteq(pretty.write({1/0, -1/0, 0/0, 1, 1/2}, ""), "{Inf,-Inf,NaN,1,0.5}")
+
+if _VERSION == "Lua 5.3" then
+    asserteq(pretty.write({1.0}, ""), "{1.0}")
+else
+    asserteq(pretty.write({1.0}, ""), "{1}")
 end
-
-testm(123,'123B')
-testm(1234,'1.2KiB')
-testm(10*1024,'10.0KiB')
-testm(1024*1024,'1.0MiB')
-
-function testn(x,s)
-  asserteq(pretty.number(x,'N',2),s)
-end
-
-testn(123,'123')
-testn(1234,'1.23K')
-testn(10*1024,'10.24K')
-testn(1024*1024,'1.05M')
-testn(1024*1024*1024,'1.07B')
-
-function testc(x,s)
-  asserteq(pretty.number(x,'T'),s)
-end
-
-testc(123,'123')
-testc(1234,'1,234')
-testc(12345,'12,345')
-testc(123456,'123,456')
-testc(1234567,'1,234,567')
-testc(12345678,'12,345,678')
-
-asserteq(pretty.number(1e12,'N'),'1000.0B')
-


### PR DESCRIPTION
* Improve precision: use %.17g for floats and %d for integers.
* Format infinities and NaN in platform-independent way.
* Add two tests.
* Fix pretty.number accidentally converting integer input to float on Lua 5.3.