### PR TITLE
Add "filename: " prefix to read errors in utils.readfile

### DIFF
--- a/lua/pl/utils.lua
+++ b/lua/pl/utils.lua
@@ -122,11 +122,15 @@ local raise
 function utils.readfile(filename,is_bin)
     local mode = is_bin and 'b' or ''
     utils.assert_string(1,filename)
-    local f,err = io.open(filename,'r'..mode)
-    if not f then return utils.raise (err) end
-    local res,err = f:read('*a')
+    local f,open_err = io.open(filename,'r'..mode)
+    if not f then return utils.raise (open_err) end
+    local res,read_err = f:read('*a')
     f:close()
-    if not res then return raise (err) end
+    if not res then
+        -- Errors in io.open have "filename: " prefix,
+        -- error in file:read don't, add it.
+        return raise (filename..": "..read_err)
+    end
     return res
 end
 


### PR DESCRIPTION
Read errors typically occur when filename actually points to
a directory. Unlike io.open, file:read doesn't prepend filename to
error message, so that using assert(utils.readfile(...)) produces
an uninformative error in this case. Fix it by adding
the prefix manually.