### PR TITLE
Add utils.quote_arg

### DIFF
--- a/lua/pl/app.lua
+++ b/lua/pl/app.lua
@@ -85,11 +85,7 @@ function app.lua ()
     end
     local cmd, append = {}, table.insert
     for i = imin,-1 do
-        local a = args[i]
-        if a:match '%s' then
-            a = '"'..a..'"'
-        end
-        append(cmd,a)
+        append(cmd, utils.quote_arg(args[i]))
     end
     return table.concat(cmd,' '),args[imin]
 end

--- a/lua/pl/dir.lua
+++ b/lua/pl/dir.lua
@@ -108,22 +108,12 @@ function dir.getdirectories(dir)
     return _listfiles(dir,false)
 end
 
-local function quote_argument (f)
-    f = path.normcase(f)
-    if f:find '%s' then
-        return '"'..f..'"'
-    else
-        return f
-    end
-end
-
-
 local alien,ffi,ffi_checked,CopyFile,MoveFile,GetLastError,win32_errors,cmd_tmpfile
 
 local function execute_command(cmd,parms)
    if not cmd_tmpfile then cmd_tmpfile = path.tmpname () end
    local err = path.is_windows and ' > ' or ' 2> '
-    cmd = cmd..' '..parms..err..cmd_tmpfile
+    cmd = cmd..' '..parms..err..utils.quote_arg(cmd_tmpfile)
     local ret = utils.execute(cmd)
     if not ret then
         local err = (utils.readfile(cmd_tmpfile):gsub('\n(.*)',''))
@@ -194,7 +184,7 @@ local function find_ffi_copyfile ()
 end
 
 local function two_arguments (f1,f2)
-    return quote_argument(f1)..' '..quote_argument(f2)
+    return utils.quote_arg(f1)..' '..utils.quote_arg(f2)
 end
 
 local function file_op (is_copy,src,dest,flag)
@@ -213,7 +203,7 @@ local function file_op (is_copy,src,dest,flag)
             local res, err = execute_command('copy',two_arguments(src,dest))
             if not res then return false,err end
             if not is_copy then
-                return execute_command('del',quote_argument(src))
+                return execute_command('del',utils.quote_arg(src))
             end
             return true
         else

--- a/lua/pl/utils.lua
+++ b/lua/pl/utils.lua
@@ -225,6 +225,39 @@ function utils.array_tostring (t,temp,tostr)
     return temp
 end
 
+local is_windows = package.config:sub(1, 1) == "\\"
+
+--- Quote an argument of a command.
+-- Quotes a single argument of a command to be passed
+-- to `os.execute`, `pl.utils.execute` or `pl.utils.executeex`.
+-- @string argument the argument.
+-- @return quoted argument.
+function utils.quote_arg(argument)
+    if is_windows then
+        if argument == "" or argument:find('[ \f\t\v]') then
+            -- Need to quote the argument.
+            -- Quotes need to be escaped with backslashes;
+            -- additionally, backslashes before a quote, escaped or not,
+            -- need to be doubled.
+            -- See documentation for CommandLineToArgvW Windows function.
+            argument = '"' .. argument:gsub([[(\*)"]], [[%1%1\"]]):gsub([[\+$]], "%0%0") .. '"'
+        end
+
+        -- os.execute() uses system() C function, which on Windows passes command
+        -- to cmd.exe. Escape its special characters.
+        return (argument:gsub('["^<>!|&%%]', "^%0"))
+    else
+        if argument == "" or argument:find('[^a-zA-Z0-9_@%+=:,./-]') then
+            -- To quote arguments on posix-like systems use single quotes.
+            -- To represent an embedded single quote close quoted string ('),
+            -- add escaped quote (\'), open quoted string again (').
+            argument = "'" .. argument:gsub("'", [['\'']]) .. "'"
+        end
+
+        return argument
+    end
+end
+
 --- execute a shell command and return the output.
 -- This function redirects the output to tempfiles and returns the content of those files.
 -- @param cmd a shell command
@@ -238,11 +271,11 @@ function utils.executeex(cmd, bin)
     local outfile = os.tmpname()
     local errfile = os.tmpname()
 
-    if utils.dir_separator == '\\' and not outfile:find(':') then
+    if is_windows and not outfile:find(':') then
         outfile = os.getenv('TEMP')..outfile
         errfile = os.getenv('TEMP')..errfile
     end
-    cmd = cmd .. [[ >"]]..outfile..[[" 2>"]]..errfile..[["]]
+    cmd = cmd .. " > " .. utils.quote_arg(outfile) .. " 2> " .. utils.quote_arg(errfile)
 
     local success, retcode = utils.execute(cmd)
     local outcontent = utils.readfile(outfile, bin)

--- a/tests/test-utils.lua
+++ b/tests/test-utils.lua
@@ -1,4 +1,5 @@
 local utils = require 'pl.utils'
+local path = require 'pl.path'
 local test = require 'pl.test'
 local asserteq, T = test.asserteq, test.tuple
 
@@ -102,6 +103,19 @@ asserteq(t.b,42)
 
 chunk,err = utils.load ('a = ?','<str>')
 assert(err,[[[string "<str>"]:1: unexpected symbol near '?']])
+
+asserteq(utils.quote_arg("foo"), [[foo]])
+if path.is_windows then
+    asserteq(utils.quote_arg(""), '^"^"')
+    asserteq(utils.quote_arg('"'), '^"')
+    asserteq(utils.quote_arg([[ \]]), [[^" \\^"]])
+    asserteq(utils.quote_arg([[foo\\ bar\\" baz\]]), [[^"foo\\ bar\\\\\^" baz\\^"]])
+    asserteq(utils.quote_arg("%path% ^^!()"), [[^"^%path^% ^^^^^!()^"]])
+else
+    asserteq(utils.quote_arg(""), "''")
+    asserteq(utils.quote_arg("'"), [[''\''']])
+    asserteq(utils.quote_arg([['a\'b]]), [[''\''a\'\''b']])
+end
 
 ----- importing module tables wholesale ---
 utils.import(math)


### PR DESCRIPTION
Add a function for quoting command arguments for os.execute
and other functions using it. It correctly handles all special
symbols.

Use it in a few places where Penlight executes command.

Add tests. I've also extensively tested the function randomly using this script: https://gist.github.com/mpeterv/132cae34b55ae65394a6fc8f847010a8