### PR TITLE
pl.template: Support customising the inline escape character (default…

### DIFF
--- a/lua/pl/template.lua
+++ b/lua/pl/template.lua
@@ -57,8 +57,8 @@ local function parseDollarParen(pieces, chunk, exec_pat)
     append(pieces, format("%q", strsub(chunk,s)))
 end
 
-local function parseHashLines(chunk,brackets,esc)
-    local exec_pat = "()$(%b"..brackets..")()"
+local function parseHashLines(chunk,inline_escape,brackets,esc)
+    local exec_pat = "()"..inline_escape.."(%b"..brackets..")()"
 
     local esc_pat = esc.."+([^\n]*\n?)"
     local esc_pat1, esc_pat2 = "^"..esc_pat, "\n"..esc_pat
@@ -87,7 +87,7 @@ local template = {}
 --   * `_parent` continue looking up in this table (e.g. `_parent=_G`)
 --   * `_brackets`; default is '()', can be any suitable bracket pair
 --   * `_escape`; default is '#'
--- 
+--
 -- @string str the template string
 -- @tab[opt] env the environment
 function template.substitute(str,env)
@@ -97,7 +97,8 @@ function template.substitute(str,env)
     end
     local brackets = rawget(env,"_brackets") or '()'
     local escape = rawget(env,"_escape") or '#'
-    local code = parseHashLines(str,brackets,escape)
+    local inline_escape = rawget(env,"_inline_escape") or '$'
+    local code = parseHashLines(str,inline_escape,brackets,escape)
     local fn,err = utils.load(code,'TMP','t',env)
     if not fn then return nil,err end
     fn = fn()
@@ -113,7 +114,3 @@ function template.substitute(str,env)
 end
 
 return template
-
-
-
-

--- a/tests/test-text.lua
+++ b/tests/test-text.lua
@@ -86,6 +86,18 @@ asserteq(template.substitute(t,{_brackets='{}',_escape='>'}),[[
     print(4)
 ]])
 
+t = [[
+#@ for i = 1,3 do
+    print(@{i+1})
+#@ end
+]]
+
+asserteq(template.substitute(t,{_brackets='{}',_escape='#@',_inline_escape='@'}),[[
+    print(2)
+    print(3)
+    print(4)
+]])
+
 --- iteration using pairs is usually unordered. But using OrderedMap
 --- we can get the exact original ordering.
 


### PR DESCRIPTION
Brackets and the line escape are already configurable. After this patch the inline escape character `$` can also be customised.