### PR TITLE
Call pl.import_into() twice during tests, to trigger more code paths

### DIFF
--- a/tests/test-import_into.lua
+++ b/tests/test-import_into.lua
@@ -25,3 +25,6 @@ assert(pl.utils)
 assert(pl.tablex)
 assert(pl.data)
 -- and so forth
+
+local pl_G = require 'pl.import_into'(_G)
+local pl_G_twice = require 'pl.import_into'(_G)


### PR DESCRIPTION
Fixes the reduced coverage of #215.