### PR TITLE
Import pl classes before attaching their metatable

### DIFF
--- a/lua/pl/Map.lua
+++ b/lua/pl/Map.lua
@@ -11,7 +11,6 @@
 
 local tablex = require 'pl.tablex'
 local utils = require 'pl.utils'
-local List = require 'pl.List'
 local stdmt = utils.stdmt
 local tmakeset,deepcompare,merge,keys,difference,tupdate = tablex.makeset,tablex.deepcompare,tablex.merge,tablex.keys,tablex.difference,tablex.update
 
@@ -24,10 +23,6 @@ local class = require 'pl.class'
 -- the Map class ---------------------
 class(nil,nil,Map)
 
-local function makemap (m)
-    return setmetatable(m,Map)
-end
-
 function Map:_init (t)
     local mt = getmetatable(t)
     if mt == Set or mt == Map then
@@ -39,7 +34,7 @@ end
 
 
 local function makelist(t)
-    return setmetatable(t,List)
+    return setmetatable(t, require('pl.List'))
 end
 
 --- list of keys.

--- a/lua/pl/array2d.lua
+++ b/lua/pl/array2d.lua
@@ -28,7 +28,7 @@ local function obj (int,out)
 end
 
 local function makelist (res)
-    return setmetatable(res,utils.stdmt.List)
+    return setmetatable(res, require('pl.List'))
 end
 
 

--- a/lua/pl/data.lua
+++ b/lua/pl/data.lua
@@ -45,10 +45,10 @@ local function strip (s)
     return (rstrip(s):gsub('^%s*',''))
 end
 
--- this gives `l` the standard List metatable, so that if you
--- do choose to pull in pl.List, you can use its methods on such lists.
-local function make_list(l)
-    return setmetatable(l,utils.stdmt.List)
+-- This gives `l` the standard List metatable,
+-- pulling in the List module.
+local function makelist(l)
+    return setmetatable(l, require('pl.List'))
 end
 
 local function map(fun,t)
@@ -79,7 +79,7 @@ local function split(line,delim,csv,n)
         -- in CSV mode trailiing commas are significant!
         if line:match ',$' then append(res,'') end
     end
-    return make_list(res)
+    return makelist(res)
 end
 
 local function find(t,v)
@@ -97,17 +97,17 @@ local DataMT = {
         for res in data.query(self,name) do
             append(arr,res)
         end
-        return make_list(arr)
+        return makelist(arr)
     end,
 
     copy_select = function(self,condn)
         condn = parse_select(condn,self)
         local iter = data.query(self,condn)
         local res = {}
-        local row = make_list{iter()}
+        local row = makelist{iter()}
         while #row > 0 do
             append(res,row)
-            row = make_list{iter()}
+            row = makelist{iter()}
         end
         res.delim = self.delim
         return data.new(res,split(condn.fields,','))
@@ -402,7 +402,7 @@ function data.new (d,fieldnames)
         d.delim = guess_delim(d.fieldnames)
         d.fieldnames = split(d.fieldnames,d.delim)
     end
-    d.fieldnames = make_list(d.fieldnames)
+    d.fieldnames = makelist(d.fieldnames)
     d.original_fieldnames = {}
     massage_fieldnames(d.fieldnames,d.original_fieldnames)
     setmetatable(d,DataMT)

--- a/lua/pl/dir.lua
+++ b/lua/pl/dir.lua
@@ -18,9 +18,12 @@ local append = table.insert
 local wrap = coroutine.wrap
 local yield = coroutine.yield
 local assert_arg,assert_string,raise = utils.assert_arg,utils.assert_string,utils.raise
-local List = utils.stdmt.List
 
 local dir = {}
+
+local function makelist(l)
+    return setmetatable(l, require('pl.List'))
+end
 
 local function assert_dir (n,val)
     assert_arg(n,val,'string',path.isdir,'not a directory',4)
@@ -63,7 +66,7 @@ function dir.filter(filenames,pattern)
     for i,f in ipairs(filenames) do
         if path.normcase(f):find(mask) then append(res,f) end
     end
-    return setmetatable(res,List)
+    return makelist(res)
 end
 
 local function _listfiles(dir,filemode,match)
@@ -78,7 +81,7 @@ local function _listfiles(dir,filemode,match)
             end
         end
     end
-    return setmetatable(res,List)
+    return makelist(res)
 end
 
 --- return a list of all files in a directory which match the a shell pattern.
@@ -266,7 +269,7 @@ local function _dirfiles(dir,attrib)
             end
         end
     end
-    return setmetatable(dirs,List),setmetatable(files,List)
+    return makelist(dirs), makelist(files)
 end
 
 
@@ -466,7 +469,7 @@ function dir.getallfiles( start_path, pattern )
         end
     end
 
-    return setmetatable(files,List)
+    return makelist(files)
 end
 
 return dir

--- a/lua/pl/seq.lua
+++ b/lua/pl/seq.lua
@@ -12,8 +12,6 @@ local io = io
 local utils = require 'pl.utils'
 local callable = require 'pl.types'.is_callable
 local function_arg = utils.function_arg
-local _List = utils.stdmt.List
-local _Map = utils.stdmt.Map
 local assert_arg = utils.assert_arg
 local debug = require 'debug'
 
@@ -160,7 +158,7 @@ function seq.copy(iter)
         res[k] = v
         k = k + 1
     end
-    setmetatable(res,_List)
+    setmetatable(res, require('pl.List'))
     return res
 end
 
@@ -255,7 +253,7 @@ function seq.count_map(iter)
         if v then t[s] = v + 1
         else t[s] = 1 end
     end
-    return setmetatable(t,_Map)
+    return setmetatable(t, require('pl.Map'))
 end
 
 -- given a sequence, return all the unique values in that sequence.

--- a/lua/pl/stringx.lua
+++ b/lua/pl/stringx.lua
@@ -19,7 +19,7 @@ local sub = string.sub
 local concat = table.concat
 local escape = utils.escape
 local ceil, max = math.ceil, math.max
-local assert_arg,usplit,list_MT = utils.assert_arg,utils.split,utils.stdmt.List
+local assert_arg,usplit = utils.assert_arg,utils.split
 local lstrip
 
 local function assert_string (n,s)
@@ -32,6 +32,10 @@ end
 
 local function assert_nonempty_string(n,s)
     assert_arg(n,s,'string',non_empty,'must be a non-empty string')
+end
+
+local function makelist(l)
+    return setmetatable(l, require('pl.List'))
 end
 
 local stringx = {}
@@ -139,7 +143,7 @@ function stringx.splitlines (s,keepends)
     local res = usplit(s,'[\r\n]')
     -- we are currently hacking around a problem with utils.split (see stringx.split)
     if #res == 0 then res = {''} end
-    return setmetatable(res,list_MT)
+    return makelist(res)
 end
 
 --- split a string into a list of strings using a delimiter.
@@ -161,7 +165,7 @@ function stringx.split(s,re,n)
     if re and re ~= '' and find(s,re,-#re,true) then
         res[#res+1] = ""
     end
-	return setmetatable(res,list_MT)
+	return makelist(res)
 end
 
 --- replace all tabs in s with tabsize spaces. If not specified, tabsize defaults to 8.

--- a/lua/pl/text.lua
+++ b/lua/pl/text.lua
@@ -25,10 +25,13 @@ local bind1,usplit,assert_arg = utils.bind1,utils.split,utils.assert_arg
 local is_callable = require 'pl.types'.is_callable
 local unpack = utils.unpack
 
+local function makelist(l)
+    return setmetatable(l, require('pl.List'))
+end
+
 local function lstrip(str)  return (str:gsub('^%s+',''))  end
 local function strip(str)  return (lstrip(str):gsub('%s+$','')) end
-local function make_list(l)  return setmetatable(l,utils.stdmt.List) end
-local function split(s,delim)  return make_list(usplit(s,delim)) end
+local function split(s,delim)  return makelist(usplit(s,delim)) end
 
 local function imap(f,t,...)
     local res = {}
@@ -91,7 +94,7 @@ function text.wrap (s,width)
         i = i + #line
         append(lines,strip(line))
     end
-    return make_list(lines)
+    return makelist(lines)
 end
 
 --- format a paragraph so that it fits into a line width.


### PR DESCRIPTION
Whenever Map, List, or Set is used as a metatable it's fetched using `require('pl.<class>')` instead of through `pl.utils.stdmt`, so that all methods are set up. Fixes #144.