### PR TITLE
fix os.execute

### DIFF
--- a/lua/pl/compat.lua
+++ b/lua/pl/compat.lua
@@ -11,6 +11,12 @@ local compat = {}
 
 compat.lua51 = _VERSION == 'Lua 5.1'
 
+local isJit = (tostring(assert):match('builtin') ~= nil)
+if isJit then
+    -- 'goto' is a keyword when 52 compatibility is enabled in LuaJit
+    compat.jit52 = not loadstring("local goto = 1")
+end
+
 --- execute a shell command.
 -- This is a compatibility function that returns the same for Lua 5.1 and Lua 5.2
 -- @param cmd a shell command
@@ -18,7 +24,7 @@ compat.lua51 = _VERSION == 'Lua 5.1'
 -- @return actual return code
 function compat.execute (cmd)
     local res1,res2,res2 = os.execute(cmd)
-    if compat.lua51 then
+    if compat.lua51 and not compat.jit52 then
         return res1==0,res1
     else
         return not not res1,res2
@@ -47,7 +53,7 @@ end
 -- @function compat.setfenv
 
 if compat.lua51 then -- define Lua 5.2 style load()
-    if not tostring(assert):match 'builtin' then -- but LuaJIT's load _is_ compatible
+    if not isJit then -- but LuaJIT's load _is_ compatible
         local lua51_load = load
         function compat.load(str,src,mode,env)
             local chunk,err


### PR DESCRIPTION
fix `utils.execute` to return proper results when LuaJIT is being used with 52 compatibility enabled.

OpenResty just switched in having this enabled by default in their latest release, hence causing troubles...