### PR TITLE
Workaround for error in pretty.load with a C hook

### DIFF
--- a/lua/pl/pretty.lua
+++ b/lua/pl/pretty.lua
@@ -46,7 +46,12 @@ local pretty = {}
 local function save_global_env()
     local env = {}
     env.hook, env.mask, env.count = debug.gethook()
-    debug.sethook()
+    
+    -- env.hook is "external hook" if is a C hook function
+	if env.hook~="external hook" then
+	    debug.sethook()
+	end
+    
     env.string_mt = getmetatable("")
     debug.setmetatable("", nil)
     return env
@@ -55,7 +60,9 @@ end
 local function restore_global_env(env)
     if env then
         debug.setmetatable("", env.string_mt)
-        debug.sethook(env.hook, env.mask, env.count)
+        if env.hook~="external hook" then
+            debug.sethook(env.hook, env.mask, env.count)
+        end
     end
 end
 


### PR DESCRIPTION
pretty.load errors out, if a C hook function is installed (Lua 5.1). Reason: debug.gethook() returns a string as first return value in this case.  Then debug.sethook complains about the first argument being a string not a function.