### PR TITLE
change compat.execute to behave similarly on Lua 5.1 and Lua > 5.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ env:
   - LUA="lua 5.2"
   - LUA="lua 5.3"
   - LUA="luajit 2.0"
+  - LUA="luajit 2.0 --compat 5.2"
+  - LUA="luajit 2.1"
+  - LUA="luajit 2.1 --compat 5.2"
 
 before_install:
   - pip install hererocks

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,9 @@ environment:
   - LUA: "lua 5.2"
   - LUA: "lua 5.3"
   - LUA: "luajit 2.0"
+  - LUA: "luajit 2.0 --compat 5.2"
+  - LUA: "luajit 2.1"
+  - LUA: "luajit 2.1 --compat 5.2"
 
 before_build:
   - set PATH=C:\Python27\Scripts;%PATH%

--- a/lua/pl/compat.lua
+++ b/lua/pl/compat.lua
@@ -17,6 +17,9 @@ if isJit then
     compat.jit52 = not loadstring("local goto = 1")
 end
 
+compat.dir_separator = _G.package.config:sub(1,1)
+compat.is_windows = compat.dir_separator == '\\'
+
 --- execute a shell command.
 -- This is a compatibility function that returns the same for Lua 5.1 and Lua 5.2
 -- @param cmd a shell command
@@ -25,9 +28,20 @@ end
 function compat.execute (cmd)
     local res1,_,res3 = os.execute(cmd)
     if compat.lua51 and not compat.jit52 then
-        return res1==0,res1
+        if compat.is_windows then
+            res1 = res1 > 255 and res1 % 256 or res1
+            return res1==0,res1
+        else
+            res1 = res1 > 255 and res1 / 256 or res1
+            return res1==0,res1
+        end
     else
-        return not not res1,res3
+        if compat.is_windows then
+            res3 = res3 > 255 and res3 % 256 or res3
+            return res3==0,res3
+        else
+            return not not res1,res3
+        end
     end
 end
 

--- a/lua/pl/path.lua
+++ b/lua/pl/path.lua
@@ -117,7 +117,7 @@ local function at(s,i)
     return sub(s,i,i)
 end
 
-path.is_windows = utils.dir_separator == '\\'
+path.is_windows = utils.is_windows
 
 local other_sep
 -- !constant sep is the directory separator for this platform.
@@ -301,7 +301,7 @@ function path.normpath(P)
     else
         -- According to POSIX, in path start '//' and '/' are distinct,
         -- but '///+' is equivalent to '/'.
-        if P:match '^//' and at(P, 3) ~= '/' then 
+        if P:match '^//' and at(P, 3) ~= '/' then
             anchor = '//'
             P = P:sub(3)
         elseif at(P, 1) == '/' then

--- a/lua/pl/utils.lua
+++ b/lua/pl/utils.lua
@@ -17,7 +17,8 @@ local utils = {
     getfenv = compat.getfenv,
     load = compat.load,
     execute = compat.execute,
-    dir_separator = _G.package.config:sub(1,1),
+    dir_separator = compat.dir_separator,
+    is_windows = compat.is_windows,
     unpack = unpack
 }
 
@@ -225,7 +226,7 @@ function utils.array_tostring (t,temp,tostr)
     return temp
 end
 
-local is_windows = package.config:sub(1, 1) == "\\"
+local is_windows = utils.is_windows
 
 --- Quote an argument of a command.
 -- Quotes a single argument of a command to be passed

--- a/tests/test-executeex.lua
+++ b/tests/test-executeex.lua
@@ -1,30 +1,29 @@
-local compat = require 'pl.compat'
 local path = require 'pl.path'
 local utils = require 'pl.utils'
 local asserteq = require 'pl.test'.asserteq
 
 local echo_lineending = "\n"
-local retcode_multiplier = 1
 if path.is_windows then
     echo_lineending = " \n"
-else
-    if compat.lua51 and not compat.jit52 then
-        retcode_multiplier = 256
-    end
 end
 
 local function test_executeex(cmd, expected_successful, expected_retcode, expected_stdout, expected_stderr)
     local successful, retcode, stdout, stderr = utils.executeex(cmd)
     asserteq(successful, expected_successful)
-    asserteq(retcode,    expected_retcode * retcode_multiplier)
+    asserteq(retcode,    expected_retcode)
     asserteq(stdout,     expected_stdout)
     asserteq(stderr,     expected_stderr)
 end
 
 -- Check the return codes
-test_executeex("exit",    true,   0, "", "")
-test_executeex("exit 0",  true,   0, "", "")
-test_executeex("exit 13", false, 13, "", "")
+test_executeex("exit",       true,    0, "", "")
+test_executeex("exit 0",     true,    0, "", "")
+test_executeex("exit 1",     false,   1, "", "")
+test_executeex("exit 13",    false,  13, "", "")
+test_executeex("exit 255",   false, 255, "", "")
+test_executeex("exit 256",   true,    0, "", "")
+test_executeex("exit 257",   false,   1, "", "")
+test_executeex("exit 3809",  false, 225, "", "")
 
 -- Check output strings
 test_executeex("echo stdout",                         true, 0, "stdout" .. echo_lineending, "")


### PR DESCRIPTION
This PR will make compatibility enhancements to `compat.execute`.