### PR TITLE
split the templating engine in a compile and render step

### DIFF
--- a/doc/manual/03-strings.md
+++ b/doc/manual/03-strings.md
@@ -140,7 +140,11 @@ So a template generating an HTML list would look like this:
 Assume the text is inside `tmpl`, then the template can be expanded using:
 
     local template = require 'pl.template'
-    res = template.substitute(tmpl,{T = {'one','two','three'}})
+    local my_env = {
+      ipairs = ipairs,
+      T = {'one','two','three'}
+    }
+    res = template.substitute(tmpl, my_env)
 
 and we get
 

--- a/tests/test-template.lua
+++ b/tests/test-template.lua
@@ -1,0 +1,95 @@
+local template = require 'pl.template'
+
+
+--------------------------------------------------
+-- Test using no leading nor trailing linebreak
+local tmpl = [[<ul>
+# for i,val in ipairs(T) do
+<li>$(i) = $(val:upper())</li>
+# end
+</ul>]]
+
+local my_env = {
+  ipairs = ipairs,
+  T = {'one','two','three'},
+  _debug = true,
+}
+local res, err = template.substitute(tmpl, my_env)
+
+print(res, err)
+assert(res == [[<ul>
+<li>1 = ONE</li>
+<li>2 = TWO</li>
+<li>3 = THREE</li>
+</ul>]])
+
+
+
+--------------------------------------------------
+-- Test using both leading and trailing linebreak
+local tmpl = [[
+<ul>
+# for i,val in ipairs(T) do
+<li>$(i) = $(val:upper())</li>
+# end
+</ul>
+]]
+
+local my_env = {
+  ipairs = ipairs,
+  T = {'one','two','three'},
+  _debug = true,
+}
+local res, err = template.substitute(tmpl, my_env)
+
+print(res, err)
+assert(res == [[
+<ul>
+<li>1 = ONE</li>
+<li>2 = TWO</li>
+<li>3 = THREE</li>
+</ul>
+]])
+
+
+--------------------------------------------------
+-- Test reusing a compiled template
+local tmpl = [[
+<ul>
+# for i,val in ipairs(T) do
+<li>$(i) = $(val:upper())</li>
+# end
+</ul>
+]]
+
+local my_env = {
+  ipairs = ipairs,
+  T = {'one','two','three'}
+}
+local t, err = template.compile(tmpl, nil, nil, nil, nil, true)
+local res, err, code = t:render(my_env)
+print(res, err, code)
+assert(res == [[
+<ul>
+<li>1 = ONE</li>
+<li>2 = TWO</li>
+<li>3 = THREE</li>
+</ul>
+]])
+
+
+-- reuse with different env
+local my_env = {
+  ipairs = ipairs,
+  T = {'four','five','six'}
+}
+local t, err = template.compile(tmpl, nil, nil, nil, nil, true)
+local res, err, code = t:render(my_env)
+print(res, err, code)
+assert(res == [[
+<ul>
+<li>1 = FOUR</li>
+<li>2 = FIVE</li>
+<li>3 = SIX</li>
+</ul>
+]])


### PR DESCRIPTION
This splits the template function into a compile step and a render step. This allows reusing a previously compiled template by just rendering it again using another `env`.

Backward compatible. Minor caveat is that it introduces 2 local variables in the template, but chances of name collisions are very low.

* adds (basic) tests for the template module
* reduced the string concatenation. Only one concat call is left.
* fixed a non-functional example in the docs

Please check ldoc comments to be ok.
