### PR TITLE
Fix for seq.last when given an empty sequence.

### DIFF
--- a/lua/pl/seq.lua
+++ b/lua/pl/seq.lua
@@ -434,15 +434,12 @@ end
 -- @param iter a sequence
 function seq.last (iter)
     iter = default_iter(iter)
-    local l = iter()
-    if l == nil then return nil end
+    local val, l = iter(), nil
+    if val == nil then return list{} end
     return function ()
-        local val,ll
-        val = iter()
+        val,l = iter(),val
         if val == nil then return nil end
-        ll = l
-        l = val
-        return val,ll
+        return val,l
     end
 end
 

--- a/tests/test-seq.lua
+++ b/tests/test-seq.lua
@@ -68,7 +68,11 @@ asserteq(C(seq.map(L'#_',{'one','tw'})),{3,2})
 
 --for l1,l2 in seq.last{10,20,30} do print(l1,l2) end
 
-asserteq(C2(seq.last{10,20,30}),{{20,10},{30,20}} )
+asserteq( C2(seq.last{10,20,30}),{{20,10},{30,20}} )
+
+asserteq( C2(seq.last{40}),{} )
+
+asserteq( C2(seq.last{}),{} )
 
 asserteq(
   seq{10,20,30}:map(L'_+1'):copy(),


### PR DESCRIPTION
Basically as I understand it, what `seq.last` does is, given some sequence `n`:

  - if `n` >= 2, return the next pair of items at indices `i` and `i - 1` down the stream.
  - if `n` < 2, return `nil` down the stream.

aka, `seq.last` works like a 'sliding window' where the window width fits 2 items.

However, the current implementation returns `nil` for an empty sequence, *when chaining the operators together*. This results in a script error and stacktrace as described in issue #252. In other words, the behavior between a sequence with `1` element and `0` element is different.

This PR corrects that inconsistency.