### PR TITLE
Fix error in 'pl.lapp.process_options_string'

### DIFF
--- a/lua/pl/lapp.lua
+++ b/lua/pl/lapp.lua
@@ -313,8 +313,8 @@ function lapp.process_options_string(str,args)
                     ps.converter = converter
                 end
                 ps.constraint = types[vtype].constraint
-            elseif not builtin_types[vtype] then
-                lapp.error(vtype.." is unknown type")
+            elseif not builtin_types[vtype] and vtype then
+                lapp.error(vtype.." is unknown type")          
             end
             parms[optparm] = ps
         end


### PR DESCRIPTION
Fix error "attempt to concatenate a nil value (local 'vtype')" by
checking making sure vtype is not nil.

I encountered this error when using `ldoc` which uses penlight to compile awesome WM. The error was as follows:
```
Scanning dependencies of target ldoc                                                                                                                                                                               
[ 97%] Generating API documentation                                                                                                                                                                                
lua: /usr/share/lua/5.3/pl/lapp.lua:317: attempt to concatenate a nil value (local 'vtype')                                                                                                                        
stack traceback:
        /usr/share/lua/5.3/pl/lapp.lua:317: in function 'pl.lapp.process_options_string'
        (...tail calls...)
        /usr/bin/ldoc:79: in main chunk
        [C]: in ?
make[2]: *** [CMakeFiles/ldoc.dir/build.make:204: doc/index.html] Error 1                                                                                                                                          
make[1]: *** [CMakeFiles/Makefile2:389: CMakeFiles/ldoc.dir/all] Error 2                                                                                                                                           
make: *** [Makefile:130: all] Error 2                                       
```

I'm not sure this is the best solution to this error and I don't even know what this function does but this minor change enabled me to finish building the awesome wm package and I thought I should share it with you.