### PR TITLE
fix(template) implement forced tostring

### DIFF
--- a/lua/pl/template.lua
+++ b/lua/pl/template.lua
@@ -66,11 +66,12 @@ local function parseHashLines(chunk,inline_escape,brackets,esc,newline)
             parseDollarParen(pieces, strsub(chunk,s, ss), exec_pat, newline)
             if not e then break end
         end
+        if strsub(lua, -1, -1) == "\n" then lua = strsub(lua, 1, -2) end
         append(pieces, "\n"..lua)
         s = e + 1
     end
     append(pieces, "\nreturn __R_table\nend")
-    
+
     -- let's check for a special case where there is nothing to template, but it's
     -- just a single static string
     local short = false
@@ -113,7 +114,7 @@ function template.substitute(str,env)
         debug = rawget(env,"_debug")
     })
     if not t then return t, err end
-    
+
     return t:render(env, rawget(env,"_parent"), rawget(env,"_debug"))
 end
 
@@ -168,7 +169,7 @@ function template.compile(str, opts)
     local escape = opts.escape or '#'
     local inline_escape = opts.inline_escape or '$'
     local inline_brackets = opts.inline_brackets or '()'
-    
+
     local code, short = parseHashLines(str,inline_escape,inline_brackets,escape,opts.newline)
     local env = { __tostring = tostring }
     local fn, err = utils.load(code, chunk_name,'t',env)

--- a/lua/pl/template.lua
+++ b/lua/pl/template.lua
@@ -39,7 +39,7 @@ local function parseDollarParen(pieces, chunk, exec_pat, newline)
     for term, executed, e in chunk:gmatch(exec_pat) do
         executed = '('..strsub(executed,2,-2)..')'
         append(pieces, APPENDER..format("%q", strsub(chunk,s, term - 1)))
-        append(pieces, APPENDER..format("(%s or '')", executed))
+        append(pieces, APPENDER..format("__tostring(%s or '')", executed))
         s = e
     end
     local r
@@ -58,7 +58,7 @@ local function parseHashLines(chunk,inline_escape,brackets,esc,newline)
 
     local esc_pat = esc.."+([^\n]*\n?)"
     local esc_pat1, esc_pat2 = "^"..esc_pat, "\n"..esc_pat
-    local  pieces, s = {"return function()\nlocal __R_size, __R_table = 0, {}", n = 1}, 1
+    local  pieces, s = {"return function()\nlocal __R_size, __R_table, __tostring = 0, {}, __tostring", n = 1}, 1
     while true do
         local ss, e, lua = strfind(chunk,esc_pat1, s)
         if not e then
@@ -170,7 +170,7 @@ function template.compile(str, opts)
     local inline_brackets = opts.inline_brackets or '()'
     
     local code, short = parseHashLines(str,inline_escape,inline_brackets,escape,opts.newline)
-    local env = {}
+    local env = { __tostring = tostring }
     local fn, err = utils.load(code, chunk_name,'t',env)
     if not fn then return nil, err, code end
 

--- a/tests/test-template.lua
+++ b/tests/test-template.lua
@@ -184,6 +184,22 @@ asserteq(type(utils.load(code)), "function")
 
 
 --------------------------------------------------
+-- Test template run-time, doesn't fail on table value
+-- table.concat fails if we insert a non-string (table) value
+local tmpl = [[
+header: $(myParam)
+]]
+
+local t, err = template.compile(tmpl, { debug = true, newline = "" })
+local myParam = {}
+local res, err, code = t:render( {myParam = myParam } ) -- insert a table
+--print(res, err, code)
+asserteq(res, "header: "..tostring(myParam))
+asserteq(type(err), "nil")
+
+
+
+--------------------------------------------------
 -- Test template compile-time error
 local tmpl = [[
 header: $(this doesn't work)


### PR DESCRIPTION
if a value is not auto-coercable to a string by `table.concat` then
rendering the template would fail with a hard error being thrown,
breaking the safety promise.

Base on the added test (without the fix enabled)
```
luajit: lua/pl/template.lua:143: invalid value (table) at index 2 in table for 'concat'
stack traceback:
	[C]: in function 'concat'
	lua/pl/template.lua:143: in function 'render'
	tests/test-template.lua:194: in main chunk
	[C]: at 0x010eb0da2c
Running tests/test-template.lua failed with code 256
thijss-mbp:penlight thijs$
```

This fix will make sure that neither the compiler nor renderer will throw a Lua error, they will always return a result, or `nil + err`.