### PR TITLE
[WIP] lexer read ahead in file mode for multi-line patterns

### DIFF
--- a/docs_topics/06-data.md
+++ b/docs_topics/06-data.md
@@ -664,8 +664,7 @@ A lexical scanner is useful where you have highly-structured data which is not
 nicely delimited by newlines. For example, here is a snippet of a in-house file
 format which it was my task to maintain:
 
-    points
-(818344.1,-20389.7,-0.1),(818337.9,-20389.3,-0.1),(818332.5,-20387.8,-0.1)
+    points (818344.1,-20389.7,-0.1),(818337.9,-20389.3,-0.1),(818332.5,-20387.8,-0.1)
         ,(818327.4,-20388,-0.1),(818322,-20387.7,-0.1),(818316.3,-20388.6,-0.1)
         ,(818309.7,-20389.4,-0.1),(818303.5,-20390.6,-0.1),(818295.8,-20388.3,-0.1)
         ,(818290.5,-20386.9,-0.1),(818285.2,-20386.1,-0.1),(818279.3,-20383.6,-0.1)

--- a/tests/test-lexer.lua
+++ b/tests/test-lexer.lua
@@ -14,9 +14,9 @@ local function test_scan(str, filter, options, expected_tokens, lang)
     end
 
     asserteq(copy2(lexer[lang](str, matches, filter, options)), expected_tokens)
-    if lang == 'scan' then
+    --if lang == 'scan' then
         asserteq(copy2(lexer[lang](open(str), matches, filter, options)), expected_tokens)
-    end
+    --end
 end
 
 local s = '20 = hello'


### PR DESCRIPTION
fixes #271 

This is not complete.

 - [ ] tests if the multiline match never completes (opening is there, closing is missing)
 - [ ] if multiline never completes: reset line numbering, to validate!
 - [ ] update docs: matchers now have an extra argument
 - [ ] cleanup comments (see diff)