### PR TITLE
Use consistent element order in pretty.write

### DIFF
--- a/lua/pl/pretty.lua
+++ b/lua/pl/pretty.lua
@@ -248,7 +248,16 @@ function pretty.write (tbl,space,not_clever)
                     used[i] = true
                 end
             end
-            for key,val in pairs(t) do
+            local ordered_keys = {}
+            for k,v in pairs(t) do
+               if type(k) ~= 'number' then
+                  ordered_keys[#ordered_keys + 1] = k
+               end
+            end
+            table.sort(ordered_keys)
+            for i = 1, #ordered_keys do
+                local key = ordered_keys[i]
+                local val = t[key]
                 local tkey = type(key)
                 local numkey = tkey == 'number'
                 if not_clever then

--- a/lua/pl/pretty.lua
+++ b/lua/pl/pretty.lua
@@ -255,9 +255,7 @@ function pretty.write (tbl,space,not_clever)
                end
             end
             table.sort(ordered_keys)
-            for i = 1, #ordered_keys do
-                local key = ordered_keys[i]
-                local val = t[key]
+            local function write_entry (key, val)
                 local tkey = type(key)
                 local numkey = tkey == 'number'
                 if not_clever then
@@ -276,6 +274,16 @@ function pretty.write (tbl,space,not_clever)
                         writeit(val,indent,newindent)
                     end
                 end
+            end
+            for i = 1, #ordered_keys do
+                local key = ordered_keys[i]
+                local val = t[key]
+                write_entry(key, val)
+            end
+            for key,val in pairs(t) do
+               if type(key) == 'number' then
+                  write_entry(key, val)
+               end
             end
             tables[t] = nil
             eat_last_comma()


### PR DESCRIPTION
Having consistent output makes it easier to use it for test purposes,
such as when dumping tables and comparing it to some expected output.
