### PR TITLE
fix(path) return original casing instead of normalized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
   - `app.require_here` will now properly handle an absolute base path
   - `stringx.split` will no longer append an empty match if the number of requested
     elements has already been reached.
+  - `path.common_prefix` and `path.relpath` return the result in the original casing
+    (only impacted Windows)
+  - `dir.copyfile`, `dir.movefile`, and `dir.makepath` create the new file/path with
+    the requested casing, and no longer force lowercase (only impacted Windows)
 
 ## 1.6.0 (2018-11-23)
 

--- a/lua/pl/app.lua
+++ b/lua/pl/app.lua
@@ -37,7 +37,9 @@ function app.require_here (base)
         p = p..path.sep
     end
     if base then
-        base = path.normcase(base)
+        if path.is_windows then
+            base = base:gsub('/','\\')
+        end
         if path.isabs(base) then
             p = base .. path.sep
         else

--- a/lua/pl/dir.lua
+++ b/lua/pl/dir.lua
@@ -80,7 +80,7 @@ local function _listfiles(dir,filemode,match)
     return makelist(res)
 end
 
---- return a list of all files in a directory which match the a shell pattern.
+--- return a list of all files in a directory which match a shell pattern.
 -- @string dir A directory. If not given, all files in current directory are returned.
 -- @string mask  A shell pattern. If not given, all files are returned.
 -- @treturn {string} list of files
@@ -196,8 +196,10 @@ local function file_op (is_copy,src,dest,flag)
         -- fallback if there's no Alien, just use DOS commands *shudder*
         -- 'rename' involves a copy and then deleting the source.
         if not CopyFile then
-            src = path.normcase(src)
-            dest = path.normcase(dest)
+            if path.is_windows then
+                src = src:gsub("/","\\")
+                dest = dest:gsub("/","\\")
+            end
             local res, err = execute_command('copy',two_arguments(src,dest))
             if not res then return false,err end
             if not is_copy then
@@ -350,7 +352,10 @@ end
 -- @raise failure to create
 function dir.makepath (p)
     assert_string(1,p)
-    return _makepath(path.normcase(path.abspath(p)))
+    if path.is_windows then
+        p = p:gsub("/", "\\")
+    end
+    return _makepath(path.abspath(p))
 end
 
 

--- a/tests/test-dir.lua
+++ b/tests/test-dir.lua
@@ -39,10 +39,10 @@ asserteq(test_samples, {
 -- Test move files -----------------------------------------
 
 -- Create a dummy file
-local fileName = path.tmpname()
+local fileName = path.tmpname() .. "Xx"
 file.write( fileName, string.rep( "poot ", 1000 ) )
 
-local newFileName = path.tmpname()
+local newFileName = path.tmpname() .. "Xx"
 local err, msg = dir.movefile( fileName, newFileName )
 
 -- Make sure the move is successful
@@ -53,6 +53,18 @@ asserteq( path.exists( fileName ), false )
 
 -- Check to make sure the new file is there
 asserteq( path.exists( newFileName ) , newFileName )
+
+-- Test existence again, but explicitly check for correct casing
+local files = dir.getfiles(path.dirname(newFileName))
+local found = false
+for i, filename in ipairs(files) do
+  if filename == newFileName then
+    found = true
+    break
+  end
+end
+assert(found, "file was not found in directory, check casing: " .. newFileName)
+
 
 -- Try to move the original file again (which should fail)
 local newFileName2 = path.tmpname()
@@ -69,7 +81,7 @@ file.delete( newFileName )
 local fileName = path.tmpname()
 file.write( fileName, string.rep( "poot ", 1000 ) )
 
-local newFileName = path.tmpname()
+local newFileName = path.tmpname() .. "xX"
 local err, msg = dir.copyfile( fileName, newFileName )
 
 -- Make sure the move is successful
@@ -77,6 +89,18 @@ assert( err, msg )
 
 -- Check to make sure the new file is there
 asserteq( path.exists( newFileName ) , newFileName )
+
+-- Test existence again, but explicitly check for correct casing
+local files = dir.getfiles(path.dirname(newFileName))
+local found = false
+for i, filename in ipairs(files) do
+  if filename == newFileName then
+    found = true
+    break
+  end
+end
+assert(found, "file was not found in directory, check casing: " .. newFileName)
+
 
 -- Try to move a non-existant file (which should fail)
 local fileName2 = 'blub'
@@ -87,6 +111,49 @@ asserteq( err, false )
 -- Clean up the files
 file.delete( fileName )
 file.delete( newFileName )
+
+
+
+-- Test make directory -----------------------------------------
+
+-- Create a dummy file
+local dirName = path.tmpname() .. "xX"
+local fullPath = dirName .. "/and/one/more"
+if path.is_windows then
+    fullPath = fullPath:gsub("/", "\\")
+end
+local err, msg = dir.makepath(fullPath)
+
+-- Make sure the move is successful
+assert( err, msg )
+
+-- Check to make sure the new file is there
+assert(path.isdir(dirName))
+assert(path.isdir(fullPath))
+
+-- Test existence again, but explicitly check for correct casing
+local files = dir.getdirectories(path.dirname(path.tmpname()))
+local found = false
+for i, filename in ipairs(files) do
+  if filename == dirName then
+    found = true
+    break
+  end
+end
+assert(found, "dir was not found in directory, check casing: " .. newFileName)
+
+
+-- Try to move a non-existant file (which should fail)
+local fileName2 = 'blub'
+local newFileName2 = 'snortsh'
+local err, msg = dir.copyfile( fileName2, newFileName2 )
+asserteq( err, false )
+
+-- Clean up the files
+file.delete( fileName )
+file.delete( newFileName )
+
+
 
 
 -- have NO idea why forcing the return code is necessary here (Windows 7 64-bit)

--- a/tests/test-path2.lua
+++ b/tests/test-path2.lua
@@ -1,23 +1,39 @@
 local path = require 'pl.path'
 local test = require 'pl.test'
-
-relpath = path.relpath
-
-path = '/a/b/c'
+local asserteq = test.asserteq
 
 function slash (p)
     return (p:gsub('\\','/'))
 end
 
+
+--  path.relpath
+
+
+local testpath = '/a/B/c'
+
 function try (p,r)
-    test.asserteq(slash(relpath(p,path)),r)
+    asserteq(slash(path.relpath(p,testpath)),r)
 end
 
-try('/a/b/c/one.lua','one.lua')
-try('/a/b/c/bonzo/two.lua','bonzo/two.lua')
-try('/a/b/three.lua','../three.lua')
+try('/a/B/c/one.lua','one.lua')
+try('/a/B/c/bonZO/two.lua','bonZO/two.lua')
+try('/a/B/three.lua','../three.lua')
 try('/a/four.lua','../../four.lua')
 try('one.lua','one.lua')
 try('../two.lua','../two.lua')
 
 
+--  path.common_prefix
+
+
+asserteq(slash(path.common_prefix("../anything","../anything/goes")),"../anything")
+asserteq(slash(path.common_prefix("../anything/goes","../anything")),"../anything")
+asserteq(slash(path.common_prefix("../anything/goes","../anything/goes")),"../anything")
+asserteq(slash(path.common_prefix("../anything/","../anything/")),"../anything")
+asserteq(slash(path.common_prefix("../anything","../anything")),"..")
+asserteq(slash(path.common_prefix("/hello/world","/hello/world/filename.doc")),"/hello/world")
+asserteq(slash(path.common_prefix("/hello/filename.doc","/hello/filename.doc")),"/hello")
+if path.is_windows then
+    asserteq(path.common_prefix("c:\\hey\\there","c:\\hey"),"c:\\hey")
+end


### PR DESCRIPTION
Use normalizing only for matching. Use original casing when applying. This problem only existed on Windows. Impacted functions:

- `path.common_prefix`: no longer forces results to lowercase
- `path.relpath`: no longer forces results to lowercase
- `dir.copyfile`: no longer creates files in forced lowercase
- `dir.movefile`: no longer moves files as forced lowercase
- `dir.makepath`: no longer creates directories as forced lowercase

Also added additional tests covering the new (and some old) behaviour.

fixes #297 
