### PR TITLE
Updates tablex readonly to assert on non-iterable/indexable data

### DIFF
--- a/lua/pl/tablex.lua
+++ b/lua/pl/tablex.lua
@@ -47,6 +47,12 @@ local function assert_arg_iterable (idx,val)
     end
 end
 
+local function assert_arg_indexable_or_iterable (idx,val)
+    if not types.is_indexable(val) or not types.is_iterable(val) then
+        complain(idx,"indexable/iterable")
+    end
+end
+
 local function assert_arg_writeable (idx,val)
     if not types.is_writeable(val) then
         complain(idx,"writeable")
@@ -985,6 +991,7 @@ end
 -- @tab t the table
 -- @return the table read only (a proxy).
 function tablex.readonly(t)
+    assert_arg_indexable_or_iterable(1,t)
     local mt = {
         __index=t,
         __newindex=function(t, k, v) error("Attempt to modify read-only table", 2) end,


### PR DESCRIPTION
Consider the case where non-indexable/non-iterable data is provided to readonly. We accomplish this by creating an empty table to return and manipulating its metatable. We make the original data the __index of the empty table, have __pairs/__ipairs call pairs/ipairs on the original data, and then we obfuscate via __metatable to restrict access to the underlying data. However if we have non-indexable or non-iterable data for __index, like a number or a string, we cannot access the data at all without extraordinary measures. ipairs/pairs will not give us anything fruitful and attempting to poke the value directly via key/index will result in nothing because the underlying data is not indexable/iterable. The only way to access the data is via debug where the obfuscated metatable can be obtained, and the readonly property is invalidated by accessing the underlying table via the __index property.