### PR TITLE
chore(stringx): clarify expandtabs + extra test

### DIFF
--- a/lua/pl/stringx.lua
+++ b/lua/pl/stringx.lua
@@ -208,7 +208,7 @@ end
 
 --- replace all tabs in s with tabsize spaces. If not specified, tabsize defaults to 8.
 -- Tab stops will be honored.
--- @string s the string
+-- @string s the string (multi-line strings are supported)
 -- @int tabsize[opt=8] number of spaces to expand each tab
 -- @return expanded string
 -- @usage stringx.expandtabs('\tone,two,three', 4)   == '    one,two,three'

--- a/spec/stringx_spec.lua
+++ b/spec/stringx_spec.lua
@@ -140,6 +140,8 @@ describe("stringx", function()
     assert.equal((' '):rep(3), stringx.expandtabs(' \t ',2))
     assert.equal((' '):rep(2), stringx.expandtabs(' \t ',0))
     assert.equal('        hi      there   folks!', stringx.expandtabs('\thi\tthere\tfolks!'))
+    -- multi line string
+    assert.equal('        hi\n        there   folks!', stringx.expandtabs('\thi\n\tthere\tfolks!'))
   end)
 
 


### PR DESCRIPTION
clarifies that the `expandtabs` function also works on multiline strings