### PR TITLE
chore(docs): typo author name in template preprocessor

### DIFF
--- a/lua/pl/template.lua
+++ b/lua/pl/template.lua
@@ -1,5 +1,5 @@
 --- A template preprocessor.
--- Originally by [Ricki Lake](http://lua-users.org/wiki/SlightlyLessSimpleLuaPreprocessor)
+-- Originally by [Rici Lake](http://lua-users.org/wiki/SlightlyLessSimpleLuaPreprocessor)
 --
 -- There are two rules:
 --


### PR DESCRIPTION
Apparently the original author's name  is "Rici" and not "Ricki".

Source: http://lua-users.org/wiki/RiciLake