### PR TITLE
fix(dir): walk follows symlinks even when follow_links=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ deprecation policy.
 see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) for release instructions
 
 ## x.x.x (unreleased)
+ - fix(dir): `walk` followed symlinks even when `follow_links=false`, causing
+   `rmtree` to delete subdirectories inside symlink targets
  - fix: tablex.mapn could take a long time if no args provided
    [#521](https://github.com/lunarmodules/Penlight/pull/521)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ deprecation policy.
 see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) for release instructions
 
 ## x.x.x (unreleased)
- - fix(dir): `walk` followed symlinks even when `follow_links=false`, causing
-   `rmtree` to delete subdirectories inside symlink targets
+ - fix(dir): `walk` followed symlinks even when `follow_links=false`, and on
+   Windows ignored `follow_links` altogether and always followed symlinks
+ - fix(dir): `rmtree` deleted subdirectories inside symlink targets due to
+   the above, and on Windows failed to delete directory symlinks with a
+   "permission denied" error
  - fix: tablex.mapn could take a long time if no args provided
    [#521](https://github.com/lunarmodules/Penlight/pull/521)
 

--- a/lua/pl/dir.lua
+++ b/lua/pl/dir.lua
@@ -289,7 +289,7 @@ end
 function dir.walk(root,bottom_up,follow_links)
     assert_dir(1,root)
     local attrib
-    if path.is_windows or follow_links then
+    if follow_links then
         attrib = path.attrib
     else
         attrib = path.link_attrib

--- a/lua/pl/dir.lua
+++ b/lua/pl/dir.lua
@@ -289,7 +289,7 @@ end
 function dir.walk(root,bottom_up,follow_links)
     assert_dir(1,root)
     local attrib
-    if path.is_windows or not follow_links then
+    if path.is_windows or follow_links then
         attrib = path.attrib
     else
         attrib = path.link_attrib

--- a/lua/pl/dir.lua
+++ b/lua/pl/dir.lua
@@ -341,8 +341,16 @@ function dir.rmtree(fullpath)
             end
         else
             for i,f in ipairs(files) do
-                local res, err = remove(path.join(root,f))
-                if not res then return nil,err .. ": " .. path.join(root,f) end
+                local p = path.join(root,f)
+                if is_windows and path.islink(p) and path.isdir(p) then
+                    -- Windows requires using "rmdir" for directory symlinks/junctions.
+                    -- Deleting them like a file fails with "permission denied".
+                    local res, err = rmdir(p)
+                    if not res then return nil,err .. ": " .. p end
+                else
+                    local res, err = remove(p)
+                    if not res then return nil,err .. ": " .. p end
+                end
             end
             local res, err = rmdir(root)
             if not res then return nil,err .. ": " .. root end

--- a/tests/test-dir.lua
+++ b/tests/test-dir.lua
@@ -196,6 +196,37 @@ do
 end
 
 
+-- test: rmtree does not delete subdirectories inside a symlink target
+do
+  local dirName = path.tmpname()
+  os.remove(dirName)
+  assert(dir.makepath(dirName))
+
+  local linkTarget = path.tmpname()
+  os.remove(linkTarget)
+  assert(dir.makepath(linkTarget))
+  local targetFile = path.normpath(linkTarget .. "/top_file.txt")
+  assert(file.write(targetFile, "hello world"))
+  local targetSubDir = path.normpath(linkTarget .. "/subdir")
+  assert(dir.makepath(targetSubDir))
+  local targetSubFile = path.normpath(targetSubDir .. "/sub_file.txt")
+  assert(file.write(targetSubFile, "hello world"))
+
+  local linkSource = path.normpath(dirName .. "/link1")
+  assert(lfs.link(linkTarget, linkSource, true))
+
+  local ok, err = dir.rmtree(dirName)
+  asserteq(ok, true)
+  asserteq(err, nil)
+
+  assert(path.exists(targetFile), "expected linked-to top file to still exist")
+  assert(path.exists(targetSubDir), "expected linked-to subdir to still exist")
+  assert(path.exists(targetSubFile), "expected linked-to subdir file to still exist")
+
+  assert(dir.rmtree(linkTarget))
+end
+
+
 -- have NO idea why forcing the return code is necessary here (Windows 7 64-bit)
 os.exit(0)
 


### PR DESCRIPTION
  - Fix inverted condition in dir.walk that selected path.attrib (stat, follows symlinks) instead of path.link_attrib (lstat) when follow_links=false
  - This caused rmtree to descend through directory symlinks and delete subdirectories inside the target, removing files outside the tree being removed
  - Add test that creates a symlink target with subdirectories and asserts they survive rmtree