### PR TITLE
lexer: recognize a preprocessor directive with no trailing newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
    "permission denied" error
  - fix: tablex.mapn could take a long time if no args provided
    [#521](https://github.com/lunarmodules/Penlight/pull/521)
+ - fix(lexer): a preprocessor directive on the final line with no trailing
+   newline is now recognized as a single `prepro` token
+   [#527](https://github.com/lunarmodules/Penlight/pull/527)
 
 ## 1.15.0 (2026-Jan-4)
  - docs: many (small) documentation updates and fixes

--- a/lua/pl/lexer.lua
+++ b/lua/pl/lexer.lua
@@ -51,6 +51,9 @@ local CHAR1 = "^''"
 local CHAR2 = [[^'(\*)%1']]
 local CHAR3 = [[^'.-[^\](\*)%1']]
 local PREPRO = '^#.-[^\\]\n'
+-- A preprocessor directive on the final line may have no trailing newline;
+-- match it up to the end of the input so it is still recognized (issue #450).
+local PREPRO_EOF = '^#.-[^\\]$'
 
 local plain_matches,lua_matches,cpp_matches,lua_keyword,cpp_keyword
 
@@ -393,6 +396,7 @@ function lexer.cpp(s,filter,options)
         cpp_matches = {
             {WSPACE,wsdump},
             {PREPRO,pdump},
+            {PREPRO_EOF,pdump},
             {NUMBER3,ndump},
             {IDEN,cpp_vdump},
             {NUMBER4,ndump},

--- a/tests/test-lexer.lua
+++ b/tests/test-lexer.lua
@@ -121,6 +121,12 @@ test_scan([['' "" " \\" '\'' "'"]], nil, nil, {
     {'string', "'"}
 }, 'cpp')
 
+-- A preprocessor directive on the final line without a trailing newline must
+-- still be recognized as a single 'prepro' token (issue #450).
+test_scan("#define ASDF", {}, nil, {
+    {'prepro', '#define ASDF'}
+}, 'cpp')
+
 local iter = lexer.lua([[
 foo
 bar


### PR DESCRIPTION
### Summary

Fixes #450. The cpp lexer does not recognize a preprocessor directive that is the last line of the input with no trailing newline.

### Root cause

`PREPRO` (`lua/pl/lexer.lua`) is `'^#.-[^\\]\n'`, which requires a literal trailing `\n` (the `[^\\]\n` tail intentionally refuses a backslash-before-newline so `\`-continued macros keep matching). A `#...` directive on the final line without a newline therefore never matches, falls through to the `^.` catch-all, and is tokenized as `#` followed by the words as identifiers:

```lua
lexer.cpp("#define ASDF")   -- {'#','#'} {'iden','define'} {'iden','ASDF'}  (wrong)
lexer.cpp("#define ASDF\n") -- {'prepro','#define ASDF\n'}                  (correct)
```

### Fix

Add a `PREPRO_EOF` pattern `'^#.-[^\\]$'` (`$` anchors to end of input) and try it right after `PREPRO` in `cpp_matches`. Newline-terminated directives still match `PREPRO` first, so multi-line and `\`-continued directives are unchanged; only a trailing directive at end-of-input now matches instead of falling through:

```lua
lexer.cpp("#define ASDF")   -- {'prepro','#define ASDF'}   (fixed)
```

### Test

Added a case to `testConsecutiveSpans`... (in `tests/test-lexer.lua`) asserting `lexer.cpp("#define ASDF")` yields a single `{'prepro','#define ASDF'}` token.

- Before the fix: the assertion fails (tokens are `#` / `define` / `ASDF`).
- After the fix: passes; the full `tests/test-lexer.lua` suite passes with no regressions (newline-terminated, multi-line, and `\`-continued directives verified unchanged).

---

Disclosure: this fix was prepared with AI assistance (Claude). I reviewed it, reproduced the bug and the fix against `pl.lexer` directly, and verified the red-green test myself.
